### PR TITLE
Minor cleanup for docs and getting_started jupyter notebook 

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -23,14 +23,15 @@ It comes with a few parts:
 1. **Quil**: The Quantum Instruction Language standard. Instructions
    written in Quil can be executed on any implementation of a quantum
    abstract machine, such as the quantum virtual machine (QVM), or on a
-   real quantum processor unit (QPU). More details regarding Quil can be
+   real quantum processing unit (QPU). More details regarding Quil can be
    found in the `whitepaper <https://arxiv.org/abs/1608.03355>`__.
-2. **QVM**: A Quantum Virtual Machine: an implementation of the quantum
+2. **QVM**: A Quantum Virtual Machine, which is an implementation of the quantum
    abstract machine on classical hardware. The QVM lets you use a
    regular computer to simulate a small quantum computer. You can access
    the Rigetti QVM running in the cloud with your API key.
+   Sign up `here <http://forest.rigetti.com>`_ to get your key.
 3. **pyQuil**: A Python library to help write and run Quil code and
-   quantum programs in Python.
+   quantum programs.
 
 Environment Setup
 -----------------
@@ -47,7 +48,7 @@ installation of Python 2.7. If you don't have pip, it can be installed with
 Installation
 ~~~~~~~~~~~~
 
-After obtaining pyQuil from `Github <https://github.com/rigetticomputing/pyQuil>`_
+After obtaining pyQuil from `GitHub <https://github.com/rigetticomputing/pyquil>`_
 or from a source distribution, navigate into its directory in a terminal and run
 
 ::
@@ -103,7 +104,7 @@ Basic Usage
 -----------
 
 To ensure that your installation is working correctly, try running the
-following Python commands interactively. First, import the ``pyquil``
+following Python commands interactively. First, import the ``quil``
 module (which constructs quantum programs) and the ``forest`` module (which
 allows connections to the Rigetti QVM). We will also import some basic
 gates for pyQuil.
@@ -138,7 +139,7 @@ Now we can make a program by adding some Quil instruction using the
 
 
 This program simply applies the :math:`X`-gate to the zeroth qubit,
-measures that qubit and stores the measurement result in the zeroth
+measures that qubit, and stores the measurement result in the zeroth
 classical register. We can look at the Quil code that makes up this
 program simply by printing it.
 
@@ -155,7 +156,7 @@ program simply by printing it.
 
 
 Most importantly, of course, we can see what happens if we run this
-program on the QVM with the following.
+program on the QVM:
 
 .. code:: python
 
@@ -210,7 +211,7 @@ different classical register we would obtain:
 
 
 We can also run programs multiple times and accumulate all the results
-in a single list. Try running this a few times to see different results.
+in a single list.
 
 .. code:: python
 
@@ -231,7 +232,7 @@ Try running the above code several times. You will see that you will,
 with very high probability, get different results each time.
 
 As the QVM is a virtual machine, we can also inspect the wavefunction of
-a program directly, even without measurements, e.g.
+a program directly, even without measurements:
 
 .. code:: python
 
@@ -246,8 +247,8 @@ a program directly, even without measurements, e.g.
     (array([ 0.70710678+0.j,  0.70710678+0.j]), [])
 
 
-The second element in this tuple is an optional amount of classical memory to check along
-with the wavefunction. For example:
+The second element in the resulting tuple is an optional amount of classical memory to check along
+with the wavefunction:
 
 .. code:: python
 
@@ -255,7 +256,8 @@ with the wavefunction. For example:
     wavf, classical_mem = qvm.wavefunction(coin_flip, classical_addresses=range(9))
 
 
-A random seed can be passed into the Connection object to make for deterministic testing.
+Additionally, we can pass a random seed to the Connection object. This allows us to reliably
+reproduce measurement results for the purpose of testing:
 
 .. code:: python
 
@@ -267,7 +269,7 @@ A random seed can be passed into the Connection object to make for deterministic
     print seeded_cxn.run(pq.Program(H(0)).measure(0, 0), [0], 20)
 
 
-It is important to remember that this is just a useful debugging tool
+It is important to remember that this ``wavefunction`` method is just a useful debugging tool
 for small quantum systems, and it cannot be feasibly obtained on a
 quantum processor.
 
@@ -623,8 +625,7 @@ Then we construct the loop in the following steps:
 
 
 Notice that the ``init_register`` program applied a Quil instruction directly to a
-classical register.  There are several classical commands that can be used in this fashion.
-They are:
+classical register.  There are several classical commands that can be used in this fashion:
 
 - ``TRUE`` which sets a single classical bit to be 1
 - ``FALSE`` which sets a single classical bit to be 0
@@ -717,7 +718,7 @@ probabilities specified.
     # 20% chance of a X gate being applied after gate applications and before measurements.
     gate_noise_probs = [0.2, 0.0, 0.0]
     meas_noise_probs = [0.2, 0.0, 0.0]
-    noisy_qvm = qvm_endpoint.Connection(gate_noise=gate_noise_probs, measurement_noise=meas_noise_probs)
+    noisy_qvm = forest.Connection(gate_noise=gate_noise_probs, measurement_noise=meas_noise_probs)
 
 We can test this by applying an :math:`X`-gate and measuring. Nominally,
 we should always measure ``1``.
@@ -741,8 +742,8 @@ Parametric Programs
 A big advantage of working in pyQuil is that you are able to leverage all the functionality of
 Python to generate Quil programs.  In quantum/classical hybrid algorithms this often leads to
 situations where complex classical functions are used to generate Quil programs. pyQuil provides
-a convenient construction to allow you to use python functions to generate templates of Quil
-programs called ParametricPrograms.  Here's a simple example:
+a convenient construction to allow you to use Python functions to generate templates of Quil
+programs, called ``ParametricPrograms``:
 
 .. code:: python
 
@@ -753,7 +754,7 @@ programs called ParametricPrograms.  Here's a simple example:
     from pyquil.parametric import ParametricProgram
     par_p = ParametricProgram(rotator) # This produces a new type of parameterized program object
 
-The ParametricProgram ``par_p`` now takes the same arguments as `rotator`, e.g.
+The parametric program ``par_p`` now takes the same arguments as ``rotator``:
 
 .. code:: python
 
@@ -763,8 +764,8 @@ The ParametricProgram ``par_p`` now takes the same arguments as `rotator`, e.g.
 
     RX(0.5) 0
 
-We can think of ParametricPrograms as a sort of template for Quil programs.  They cache computations
-that happen in python functions so that templates in Quil can be efficiently substituted.
+We can think of ``ParametricPrograms`` as a sort of template for Quil programs.  They cache computations
+that happen in Python functions so that templates in Quil can be efficiently substituted.
 
 
 Pauli Operator Algebra
@@ -853,8 +854,8 @@ calculation so that it can be used later with new values.
 Exercises
 ---------
 
-Exercise 1.
-~~~~~~~~~~~
+Exercise 1 - Quantum Dice
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Write a quantum program to simulate throwing an 8-sided die. The Python
 function you should produce is:
@@ -871,8 +872,8 @@ Next, extend the program to work for any kind of fair die:
     def throw_polyhedral_die(num_sides):
         # return the result of throwing a num_sides sided die by running a quantum program
 
-Exercise 2.
-~~~~~~~~~~~
+Exercise 2 - Controlled Gates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We can use the full generality of NumPy and SciPy to construct new gate
 matrices.
@@ -886,8 +887,8 @@ matrices.
    manner. Find the wavefunction when applying this gate to qubit 1
    controlled by qubit 0.
 
-Exercise 3.
-~~~~~~~~~~~
+Exercise 3 - Grover's Algorithm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Write a quantum program for the single-shot Grover's algorithm. The
 Python function you should produce is:
@@ -901,10 +902,7 @@ Python function you should produce is:
 
 As an example: ``single_shot_grovers([0,0,1,0])`` should return 2.
 
-Hints
-^^^^^
-
-Remember that the Grover's diffusion operator is:
+**HINT** - Remember that the Grover's diffusion operator is:
 
 .. math::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to the documentation for Forest and pyQuil!
+Welcome to the Documentation for Forest and pyQuil!
 ===================================================
 
 .. toctree::
@@ -16,7 +16,7 @@ Welcome to the documentation for Forest and pyQuil!
    source_docs
 
 
-Indices and tables
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/docs/source/next_steps.rst
+++ b/docs/source/next_steps.rst
@@ -3,7 +3,7 @@ Next Steps
 
 We hope that you have enjoyed your whirlwind tour of quantum computing.
 If you would like to learn more, Nielsen and Chuang's
-*Quantum Information and Quantum Computation* is a particularly excellent resource for
+*Quantum Computation and Quantum Information* is a particularly excellent resource for
 newcomers to the field. Also, be sure to check out the
 `resources <http://rigetti.com/resources>`_ section of the Rigetti website.
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -12,7 +12,7 @@ obtaining an API key for the beta, please reach out by signing up
 pyQuil is an open source Python library developed at
 `Rigetti Quantum Computing <http://rigetti.com>`_ that constructs
 programs for quantum computers.  The source is hosted on
-`Github <https://github.com/rigetticomputing/pyQuil>`_.
+`GitHub <https://github.com/rigetticomputing/pyquil>`_.
 
 More concretely, pyQuil produces programs in the Quantum Instruction Language (Quil).  For a full
 description of Quil, please refer to the whitepaper *A Practical Quantum Instruction Set Architecture*.

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -4,11 +4,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# pyQuil - The Quantum Programing Toolkit in Python\n",
+    "# Installation and Getting Started\n",
     "\n",
-    "This toolkit provides some simple libraries for writing quantum programs using the quantum instruction language Quil. pyQuil is part of the [Forest](http://forest.rigetti.com) suite of tools for quantum programming and is currently in beta.\n",
+    "- [Environment Setup](#Environment-Setup)\n",
+    "    - [Prerequisites](#Prerequisites)\n",
+    "    - [Installation](#Installation)\n",
+    "    - [Connecting to a Rigetti QVM](#Connecting-to-a-Rigetti-QVM)\n",
+    "- [Basic Usage](#Basic-Usage)\n",
+    "    - [Some Program Construction Features](#Some-Program-Construction-Features)\n",
+    "    - [Fixing a Mistaken Instruction](#Fixing-a-Mistaken-Instruction)\n",
+    "    - [The Standard Gate Set](#The-Standard-Gate-Set)\n",
+    "    - [Defining New Gates](#Defining-New-Gates)\n",
+    "- [Advanced Usage](#Advanced-Usage)\n",
+    "    - [Quantum Fourier Transform (QFT)](#Quantum-Fourier-Transform)\n",
+    "    - [Classical Control Flow](#Classical-Control-Flow)\n",
+    "    - [Parametric Depolarizing Noise](#Parametric-Depolarizing-Noise)\n",
+    "    - [Pauli Operator Algebra](#Pauli-Operator-Algebra)\n",
+    "- [Exercises](#Exercises)\n",
+    "    - [Exercise 1 - Quantum Dice](#Exercise-1---Quantum-Dice)\n",
+    "    - [Exercise 2 - Controlled Gates](#Exercise-2---Controlled-Gates)\n",
+    "    - [Exercise 3 - Grover's Algorithm](#Exercise-3---Grover's-Algorithm)\n",
     "\n",
-    "```\n",
+    "This toolkit provides some simple libraries for writing quantum programs using the quantum instruction language Quil. pyQuil is part of the [Forest](http://forest.rigetti.com) suite of tools for quantum programming and is currently in private beta.\n",
+    "\n",
+    "```python\n",
     "import pyquil.quil as pq\n",
     "import pyquil.forest as forest\n",
     "from pyquil.gates import *\n",
@@ -22,18 +41,18 @@
     "\n",
     "It comes with a few parts:\n",
     "\n",
-    "1. **Quil**: The Quantum Instruction Language standard. Instructions written in Quil can be executed on any implementation of a quantum abstract machine, such as the quantum virtual machine (QVM), or on a real quantum processor unit (QPU). More details regarding Quil can be found in the [whitepaper](https://arxiv.org/abs/1608.03355).\n",
-    "2. **QVM**: A Quantum Virtual Machine: an implementation of the quantum abstract machine on classical hardware.  The QVM lets you use a regular computer to simulate a small quantum computer.  You can access the Rigetti QVM running in the cloud with your API key.  [Sign up here to get your key](http://forest.rigetti.com).\n",
-    "3. **pyQuil**: A Python library to help write and run Quil code and quantum programs in Python.\n",
+    "1. **Quil**: The Quantum Instruction Language standard. Instructions written in Quil can be executed on any implementation of a quantum abstract machine, such as the quantum virtual machine (QVM), or on a real quantum processing unit (QPU). More details regarding Quil can be found in the [whitepaper](https://arxiv.org/abs/1608.03355).\n",
+    "2. **QVM**: A Quantum Virtual Machine, which is an implementation of the quantum abstract machine on classical hardware.  The QVM lets you use a regular computer to simulate a small quantum computer.  You can access the Rigetti QVM running in the cloud with your API key.  Sign up [here](http://forest.rigetti.com) to get your key.\n",
+    "3. **pyQuil**: A Python library to help write and run Quil code and quantum programs.\n",
     "\n",
-    "## Getting Started\n",
+    "## Environment Setup\n",
     "\n",
     "### Prerequisites\n",
     "\n",
-    "Before starting, ensure that you have an installation of Python 2.7.(>= 10) and pip. We recommend installing [Anaconda](https://www.continuum.io/downloads) for an all-in-one installation. If pip is not installed, it can be installed with `easy_install pip`.\n",
+    "Before starting, ensure that you have an installation of Python 2.7 (version 2.7.10 or greater) and the Python package manager pip. We recommend installing [Anaconda](https://www.continuum.io/downloads) for an all-in-one installation of Python 2.7. If pip is not installed, it can be installed with `easy_install pip`.\n",
     "\n",
     "### Installation\n",
-    "After getting pyQuil from either a repository or from a source distribution, change to that directory in a terminal and run\n",
+    "After obtaining pyQuil from [GitHub](https://github.com/rigetticomputing/pyquil) or from a source distribution, navigate into its directory in a terminal and run\n",
     "\n",
     "```\n",
     "pip install pyquil\n",
@@ -42,7 +61,7 @@
     "The library will now be available globally.\n",
     "\n",
     "### Connecting to a Rigetti QVM\n",
-    "In order to connect to a Rigetti QVM you need to configure your pyQuil installation with your QVM key. For permanent one time setup, you can do this by creating a file in your home directory with the following lines:\n",
+    "In order to connect to a Rigetti QVM you need to configure your pyQuil installation with your QVM API key. For permanent one-time setup, you can do this by creating a file in your home directory with the following lines:\n",
     "```\n",
     "[Rigetti Forest]\n",
     "url: <FOREST_URL>\n",
@@ -57,9 +76,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Basic Usage\n",
+    "## Basic Usage\n",
     "\n",
-    "To ensure that your installation is working correctly, try running the following Python commands interactively.  First, import the `pyquil` module (which constructs quantum programs) and the `qvm` module (which allows connections to the Rigetti QVM). We'll also import some basic gates for pyQuil.\n"
+    "To ensure that your installation is working correctly, try running the following Python commands interactively.  First, import the **`quil`** module (which constructs quantum programs) and the **`forest`** module (which allows connections to the Rigetti QVM). We'll also import some basic gates for pyQuil.\n"
    ]
   },
   {
@@ -110,7 +129,7 @@
     {
      "data": {
       "text/plain": [
-       "<pyquil.quil.Program at 0x7ff53887fb50>"
+       "<pyquil.quil.Program at 0x7f7ce3466c50>"
       ]
      },
      "execution_count": 3,
@@ -127,7 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This program simply applies the $X$-gate to the zeroth qubit, measures that qubit and stores the measurement result in the zeroth classical register. We can look at the Quil code that makes up this program simply by printing it."
+    "This program simply applies the $X$-gate to the zeroth qubit, measures that qubit, and stores the measurement result in the zeroth classical register. We can look at the Quil code that makes up this program simply by printing it."
    ]
   },
   {
@@ -155,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most importantly, of course, we can see what happens if we run this program on the QVM with the following."
+    "Most importantly, of course, we can see what happens if we run this program on the QVM:"
    ]
   },
   {
@@ -246,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also run programs multiple times and accumulate all the results in a single list. Try running this a few times to see different results."
+    "We can also run programs multiple times and accumulate all the results in a single list:"
    ]
   },
   {
@@ -259,7 +278,7 @@
     {
      "data": {
       "text/plain": [
-       "[[1], [1], [0], [0], [0]]"
+       "[[0], [0], [1], [0], [1]]"
       ]
      },
      "execution_count": 8,
@@ -277,9 +296,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Try running the above code several times. You will see that you will, with very high probability, get different results each time.\n",
+    "Try running the above code several times. You will, with very high probability, get different results each time.\n",
     "\n",
-    "As the QVM is a virtual machine, we can also inspect the wavefunction of a program directly, even without measurements, e.g."
+    "As the QVM is a virtual machine, we can also inspect the wavefunction of a program directly, even without measurements:"
    ]
   },
   {
@@ -309,7 +328,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is important to remember that this is just a useful debugging tool for small quantum systems, and it cannot be feasibly obtained on a quantum processor."
+    "It is important to remember that this `wavefunction` method is just a useful debugging tool for small quantum systems, and it cannot be feasibly obtained on a quantum processor."
    ]
   },
   {
@@ -423,6 +442,30 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Standard Gate Set\n",
+    "The following gates methods come standard with Quil and `gates.py`:\n",
+    "\n",
+    "- Pauli gates  `I`, `X`, `Y`, `Z`\n",
+    "\n",
+    "- Hadamard gate: `H`\n",
+    "\n",
+    "- Phase gates: `PHASE(` $\\theta$ `)`, `S`, `T`\n",
+    "\n",
+    "- Controlled phase gates: `CPHASE00(` $\\alpha$ `)`, `CPHASE01(` $\\alpha$ `)`, `CPHASE10(` $\\alpha$ `)`, `CPHASE(` $\\alpha$ `)`\n",
+    "\n",
+    "- Cartesian rotation gates: `RX(` $\\theta$ `)`, `RY(` $\\theta$ `)`, `RZ(` $\\theta$ `)`\n",
+    "\n",
+    "- Controlled $X$ gates: `CNOT`, `CCNOT`\n",
+    "\n",
+    "- Swap gates: `SWAP`, `CSWAP`, `ISWAP`, `PSWAP(` $\\alpha$ `)`\n",
+    "\n",
+    "The parameterized gates take a real or complex floating point number as an argument."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
@@ -528,7 +571,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### A More Advanced Example: QFT\n",
+    "## Advanced Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quantum Fourier Transform (QFT) <a id='Quantum-Fourier-Transform'></a>\n",
     "\n",
     "Let's do an example that includes multi-qubit parameterized gates.\n",
     "\n",
@@ -538,7 +588,7 @@
     "2. Write a state preparation quantum program.\n",
     "3. Execute state preparation followed by the QFT on the QVM.\n",
     "\n",
-    "First we define a function to make a 3-qubit QFT quantum program. This is a mix of Hadamard and CPhase gates, with a final bit reversal correction at the end consisting of a single Swap gate."
+    "First we define a function to make a 3-qubit QFT quantum program. This is a mix of Hadamard and CPHASE gates, with a final bit reversal correction at the end consisting of a single SWAP gate."
    ]
   },
   {
@@ -567,9 +617,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is a very important detail to be recognized here: The function `qft3` doesn't *compute* the QFT, but rather it *makes a quantum program* to compute the QFT on qubits `q0`, `q1`, and `q2`.\n",
+    "There is a very important detail to recognize here: The function `qft3` doesn't *compute* the QFT, but rather it *makes a quantum program* to compute the QFT on qubits `q0`, `q1`, and `q2`.\n",
     "\n",
-    "We can look at what this program looks like in Quil notation by doing the following:"
+    "We can see what this program looks like in Quil notation by doing the following:"
    ]
   },
   {
@@ -602,7 +652,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we want to prepare a state that corresponds to the sequence we want to compute the discrete Fourier transform of. Fortunately, this is easy, we just apply an X gate to the zero state."
+    "Next, we want to prepare a state that corresponds to the sequence we want to compute the discrete Fourier transform of. Fortunately, this is easy, we just apply an $X$-gate to the zeroth qubit."
    ]
   },
   {
@@ -716,7 +766,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### More Advanced Control Flow\n",
+    "### Classical Control Flow\n",
     "\n",
     "Here are a couple quick examples that show how much richer the classical control of a Quil program can be. In this first example, we have a register called `classical_flag_register` which we use for looping. Then we construct the loop in the following steps:\n",
     "\n",
@@ -724,7 +774,7 @@
     "\n",
     "2. Next, we write body of the loop in a program itself. This will be a program that computes an $X$ followed by an $H$ on our qubit.\n",
     "\n",
-    "3. Lastly, we put it all together using the `quil_while` method."
+    "3. Lastly, we put it all together using the `while_do` method."
    ]
   },
   {
@@ -738,8 +788,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "X 0\n",
-      "MEASURE 0 [2]\n",
+      "TRUE [2]\n",
       "LABEL @START1\n",
       "JUMP-UNLESS @END2 [2]\n",
       "X 0\n",
@@ -756,7 +805,7 @@
     "classical_flag_register = 2\n",
     "\n",
     "# Write out the loop initialization and body programs:\n",
-    "init_register = pq.Program(X(0)).measure(0, classical_flag_register)\n",
+    "init_register = pq.Program(TRUE([classical_flag_register]))\n",
     "loop_body = pq.Program(X(0), H(0)).measure(0, classical_flag_register)\n",
     "\n",
     "# Put it all together in a loop program:\n",
@@ -769,7 +818,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this next example, we show how to do conditional branching in the form of the traditional `if` construct as in many programming languages. Much like the last example, we construct programs for each branch of the `if`, and put it all together by using the `quil_if` method."
+    "Notice that the `init_register` program applied a Quil instruction directly to a classical register. There are several classical commands that can be used in this fashion:\n",
+    "\n",
+    "- `TRUE` which sets a single classical bit to be 1\n",
+    "- `FALSE` which sets a single classical bit to be 0\n",
+    "- `NOT` which flips a classical bit\n",
+    "- `AND` which operates on two classical bits\n",
+    "- `OR` which operates on two classical bits\n",
+    "- `MOVE` which moves the value of a classical bit at one classical address into another\n",
+    "- `EXCHANGE` which swaps the value of two classical bits\n",
+    "\n",
+    "In this next example, we show how to do conditional branching in the form of the traditional `if` construct as in many programming languages. Much like the last example, we construct programs for each branch of the `if`, and put it all together by using the `if_then` method."
    ]
   },
   {
@@ -834,7 +893,7 @@
     {
      "data": {
       "text/plain": [
-       "[[0], [1], [1], [1], [0], [1], [0], [0], [0], [0]]"
+       "[[1], [1], [0], [1], [0], [0], [0], [0], [1], [0]]"
       ]
      },
      "execution_count": 23,
@@ -850,31 +909,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The Standard Gate Set\n",
-    "The following gates methods come standard with Quil and `gates.py`:\n",
-    "\n",
-    "- Pauli gates  `I`, `X`, `Y`, `Z`\n",
-    "\n",
-    "- Hadamard gate: `H`\n",
-    "\n",
-    "- Phase gates: `PHASE(`$\\theta$`)`, `S`, `T`\n",
-    "\n",
-    "- Controlled phase gates: `CPHASE00(` $\\alpha$ `)`, `CPHASE01(` $\\alpha$ `)`, `CPHASE10(` $\\alpha$ `)`, `CPHASE(` $\\alpha$ `)`\n",
-    "\n",
-    "- Cartesian rotation gates: `RX(` $\\theta$ `)`, `RY(` $\\theta$ `)`, `RZ(` $\\theta$ `)`\n",
-    "\n",
-    "- Controlled $X$ gates: `CNOT`, `CCNOT`\n",
-    "\n",
-    "- Swap gates: `SWAP`, `CSWAP`, `ISWAP`, `PSWAP(` $\\alpha$ `)`\n",
-    "\n",
-    "The gates of a single argument take a real or complex floating point number as an argument."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Advanced: Parametric Depolarizing Noise\n",
+    "### Parametric Depolarizing Noise\n",
     "The Rigetti QVM has support for emulating certain types of noise models. One such model is *parametric depolarizing noise*, which is defined by a set of 6 probabilities:\n",
     "\n",
     "- The probabilities $P_X$, $P_Y$, and $P_Z$ which define respectively the probability of a Pauli $X$, $Y$, or $Z$ gate getting applied to *each* qubit after *every* gate application. These probabilities are called the *gate noise probabilities*.\n",
@@ -890,24 +925,12 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'qvm_endpoint' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-24-c42be5813019>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mgate_noise_probs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m0.2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mmeas_noise_probs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m0.2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0.0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mnoisy_qvm\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mqvm_endpoint\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mConnection\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mgate_noise\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mgate_noise_probs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmeasurement_noise\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmeas_noise_probs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'qvm_endpoint' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 20% chance of a X gate being applied after gate applications and before measurements.\n",
     "gate_noise_probs = [0.2, 0.0, 0.0]\n",
     "meas_noise_probs = [0.2, 0.0, 0.0]\n",
-    "noisy_qvm = qvm_endpoint.Connection(gate_noise=gate_noise_probs, measurement_noise=meas_noise_probs)"
+    "noisy_qvm = forest.Connection(gate_noise=gate_noise_probs, measurement_noise=meas_noise_probs)"
    ]
   },
   {
@@ -919,11 +942,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Without Noise: [[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]\n",
+      "With Noise   : [[1], [1], [1], [1], [1], [0], [1], [0], [1], [1]]\n"
+     ]
+    }
+   ],
    "source": [
     "p = pq.Program().inst(X(0)).measure(0, 0)\n",
     "print \"Without Noise:\", qvm.run(p, [0], 10)\n",
@@ -934,17 +966,85 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Advanced: Pauli Operator Algebra\n",
+    "### Parametric Programs\n",
+    "\n",
+    "A big advantage of working in pyQuil is that you are able to leverage all the functionality of Python to generate Quil programs. In quantum/classical hybrid algorithms this often leads to situations where complex classical functions are used to generate Quil programs. pyQuil provides a convenient construction to allow you to use Python functions to generate templates of Quil programs, called `ParametricPrograms`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# This function returns a quantum circuit with different rotation angles on a gate on qubit 0\n",
+    "def rotator(angle):\n",
+    "    return pq.Program(RX(angle, 0))\n",
+    "\n",
+    "from pyquil.parametric import ParametricProgram\n",
+    "par_p = ParametricProgram(rotator) # This produces a new type of parameterized program object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parametric program `par_p` now takes the same arguments as `rotator`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RX(0.5) 0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print par_p(0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can think of ``ParametricPrograms`` as a sort of template for Quil programs.  They cache computations\n",
+    "that happen in Python functions so that templates in Quil can be efficiently substituted."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pauli Operator Algebra\n",
     "Many algorithms require manipulating sums of Pauli combinations, such as \\\\[\\sigma = \\tfrac{1}{2}I - \\tfrac{3}{4}X_0Y_1Z_3 + (5-2i)Z_1X_2,\\\\] where $G_n$ indicates the gate $G$ acting on qubit $n$. We can represent such sums by constructing `PauliTerm` and `PauliSum`. The above sum can be constructed as follows:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sigma = 0.5*I + -0.75*X0*Y1*Z3 + (5-2j)*Z1*X2\n"
+     ]
+    }
+   ],
    "source": [
     "from pyquil.paulis import ID, sX, sY, sZ\n",
     "\n",
@@ -976,11 +1076,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Simplified  : (32.46875-30j)*I + (-16.734375+15j)*X0*Y1*Z3 + (71.5625-144.625j)*Z1*X2\n",
+      "\n",
+      "Quil to compute exp[iX] on qubit 0:\n",
+      "H 0\n",
+      "RZ(-2.0) 0\n",
+      "H 0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import pyquil.paulis as pl\n",
     "\n",
@@ -1000,7 +1114,8 @@
    "metadata": {},
    "source": [
     "## Exercises\n",
-    "### Exercise 1.\n",
+    "\n",
+    "### Exercise 1 - Quantum Dice\n",
     "\n",
     "Write a quantum program to simulate throwing an 8-sided die.  The Python function you should produce is:\n",
     "\n",
@@ -1023,7 +1138,7 @@
     "collapsed": true
    },
    "source": [
-    "### Exercise 2.\n",
+    "### Exercise 2 - Controlled Gates\n",
     "\n",
     "We can use the full generality of NumPy and SciPy to construct new gate matrices.\n",
     "\n",
@@ -1038,7 +1153,7 @@
     "collapsed": false
    },
    "source": [
-    "### Exercise 3.\n",
+    "### Exercise 3 - Grover's Algorithm\n",
     "\n",
     "Write a quantum program for the single-shot Grover's algorithm.  The Python function you should produce is:\n",
     "\n",
@@ -1051,8 +1166,7 @@
     "\n",
     "As an example: `single_shot_grovers([0,0,1,0])` should return 2.\n",
     "\n",
-    "#### Hints\n",
-    "Remember that the Grover's diffusion operator is:\n",
+    "**HINT** - Remember that the Grover's diffusion operator is:\n",
     "\n",
     "$$\n",
     "\\begin{pmatrix}\n",
@@ -1068,7 +1182,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },
@@ -1082,7 +1196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/pyquil/forest.py
+++ b/pyquil/forest.py
@@ -14,6 +14,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+"""
+Module for facilitating connections to the QVM / QPU.
+"""
 
 from __future__ import print_function
 from requests.packages.urllib3.util import Retry

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -14,7 +14,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-
 """
 A lovely bunch of gates and instructions for programming with.  This module is used to provide
 Pythonic sugar for Quil instructions.

--- a/pyquil/parametric.py
+++ b/pyquil/parametric.py
@@ -14,6 +14,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+"""
+Module for creating and defining parametric programs.
+"""
 
 import inspect
 from copy import copy

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -14,9 +14,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-
-"""Module for working with Pauli Algebras
 """
+Module for working with Pauli algebras.
+"""
+
 from itertools import product
 import numpy as np
 import copy

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -14,6 +14,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+"""
+Module for creating and defining Quil programs.
+"""
 
 import copy
 

--- a/pyquil/quil_atom.py
+++ b/pyquil/quil_atom.py
@@ -15,7 +15,7 @@
 #    limitations under the License.
 ##############################################################################
 """
-Contains the base class for Atomic Quil elements
+Contains the base class for Atomic Quil elements.
 """
 
 class QuilAtom(object):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -15,7 +15,7 @@
 #    limitations under the License.
 ##############################################################################
 """
-This module contains the core pyQuil objects that correspond to Quil instructions.
+Contains the core pyQuil objects that correspond to Quil instructions.
 """
 
 import numpy as np


### PR DESCRIPTION
Fixed some minor consistency- and clarity-related issues in the documentation, and updated the `getting_started.ipynb` notebook. The notebook now parallels the most recent iteration of the *Installation and Getting Started* page in the docs, and has a table of contents with internal anchor links.