### PR TITLE
Implemented `InstructionGroup.extract_qubits()`

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -302,6 +302,26 @@ class InstructionGroup(QuilAction):
         if 0 != len(self.actions):
             self.actions.pop()
 
+    def extract_qubits(self):
+        """
+        Return all qubit addresses involved in the instruction group.
+        """
+        qubits = set()
+        for jj, act_jj in self.actions:
+            if isinstance(act_jj, (Instr)):
+                qubits = qubits | act_jj.qubits()
+            elif isinstance(act_jj, If):
+                qubits = qubits | act_jj.Then.extract_qubits() | act_jj.Else.extract_qubits()
+            elif isinstance(act_jj, While):
+                qubits = qubits | act_jj.Body.extract_qubits()
+            elif isinstance(act_jj, InstructionGroup):
+                qubits = qubits | act_jj.extract_qubits()
+            elif isinstance(act_jj, (JumpTarget, JumpConditional, SimpleInstruction,
+                                     UnaryClassicalInstruction, BinaryClassicalInstruction, Jump)):
+                continue
+            else:
+                raise ValueError(type(act_jj))
+        return qubits
 
 class JumpTarget(AbstractInstruction):
     """

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -351,3 +351,12 @@ def test_alloc_no_free():
     p.inst(H(q2))
     assert p.out() == 'H 0\nH 1\n'
     assert p.out() == 'H 0\nH 1\n'
+
+
+def test_extract_qubits():
+    p = Program(RX(0.5)(0), RY(0.1)(1), RZ(1.4)(2))
+    assert p.extract_qubits() == set([0,1,2])
+    p.if_then(0, X(4), H(5)).measure(6, 2)
+    assert p.extract_qubits() == set([0,1,2,4,5,6])
+    p.while_do(0, Program(X(3)).measure(3, 0))
+    assert p.extract_qubits() == set([0,1,2,3,4,5,6])


### PR DESCRIPTION
This allows to extract the addresses of all qubits involved in a pyquil.Program and more generally an InstructionGroup object.