### PR TITLE
Small fixes and improvements to the sphinx-style docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ our documentation, so this may need to be installed using `pip install sphinx_rt
 
 ## Development and Testing
 
-We use pytest for testing. Tests can be run from the top-level directory using:
+We use pytest (version > 3.0) for testing. After installing pytest with `pip`, tests can be run from the top-level directory using:
 ```
-pytest --cov=pyquil
+pytest
 ```
 
 ## How to cite pyQuil and Forest

--- a/pyquil/forest.py
+++ b/pyquil/forest.py
@@ -51,6 +51,7 @@ except:
 def config_value(name, default=None):
     """
     Get a config file value for a particular name
+
     :param name: The key.
     :param default: A default if it's not found.
     :return: The value.
@@ -66,6 +67,7 @@ def env_or_config(env, name, default=None):
     """
     Get the value of the environment variable or config file value.
     The environment variable takes precedence.
+
     :param env: The environment variable name.
     :param name: The config file key.
     :param default: The default value to use.
@@ -109,7 +111,8 @@ def certificate(cert=HTTPS_CERT, key=HTTPS_KEY):
 def add_noise_to_payload(payload, gate_noise, measurement_noise):
     """
     Set the gate noise and measurement noise of a payload.
-    :param payload: Dictionary of run information.
+
+    :param dict payload: Dictionary of run information.
     :param gate_noise: Probability of a noise gate being applied at each time step.
     :param measurement_noise: Probability of a noise gate being applied before measurement.
     """
@@ -122,8 +125,9 @@ def add_noise_to_payload(payload, gate_noise, measurement_noise):
 def add_rng_seed_to_payload(payload, seed):
     """
     Add a random seed to the payload.
+
     :param payload: JSON payload.
-    :param seed: A non-negative integer.
+    :param int seed: A non-negative integer.
     """
     if seed is not None:
         payload['rng-seed'] = seed
@@ -132,7 +136,8 @@ def add_rng_seed_to_payload(payload, seed):
 def _validate_noise_probabilities(noise_parameter):
     """
     Is noise_parameter a valid specification of noise probabilities for depolarizing noise?
-    :param noise_parameter: List of noise parameter values to be validated.
+
+    :param list noise_parameter: List of noise parameter values to be validated.
     """
     if not noise_parameter:
         return
@@ -151,7 +156,8 @@ def _validate_noise_probabilities(noise_parameter):
 def _validate_run_items(run_items):
     """
     Check the validity of classical addresses / qubits for the payload.
-    :param run_items: List of classical addresses or qubits to be validated.
+
+    :param list run_items: List of classical addresses or qubits to be validated.
     """
     if not isinstance(run_items, list):
         raise TypeError("run_items must be a list")
@@ -162,6 +168,7 @@ def _validate_run_items(run_items):
 def _round_to_next_multiple(n, m):
     """
     Round up the the next multiple.
+
     :param n: The number to round up.
     :param m: The multiple.
     :return: The rounded number
@@ -172,8 +179,10 @@ def _round_to_next_multiple(n, m):
 def _octet_bits(o):
     """
     Get the bits of an octet.
+
     :param o: The octets.
     :return: The bits as a list in LSB-to-MSB order.
+    :rtype: list
     """
     if not isinstance(o, (int, long)):
         raise TypeError("o should be an int or long")
@@ -265,6 +274,7 @@ class Connection(object):
     def post_json(self, j):
         """
         Post JSON to the QVM endpoint.
+
         :param j: JSON.
         :return: A non-error response.
         """
@@ -293,7 +303,9 @@ class Connection(object):
     def ping(self):
         """
         Ping the QVM.
+
         :return: Should get "pong" back.
+        :rtype: string
         """
         payload = {"type": "ping"}
         res = self.post_json(payload)
@@ -302,7 +314,9 @@ class Connection(object):
     def version(self):
         """
         Query the QVM version.
+
         :return: The current version of the QVM.
+        :rtype: string
         """
         payload = {"type": "version"}
         res = self.post_json(payload)
@@ -311,11 +325,13 @@ class Connection(object):
     def wavefunction(self, quil_program, classical_addresses=[]):
         """
         Simulate a Quil program and get the wavefunction back.
-        :param quil_program: A Quil program.
-        :param classical_addresses: An optional list of classical addresses.
+
+        :param Program quil_program: A Quil program.
+        :param list classical_addresses: An optional list of classical addresses.
         :return: A tuple whose first element is a a NumPy array of amplitudes,
                  and whose second element is the list of classical bits corresponding
                  to the classical addresses.
+        :rtype: tuple
         """
 
         def recover_complexes(coef_string):
@@ -361,9 +377,11 @@ class Connection(object):
         """
         Calculate the expectation value of operators given a state prepared by
         prep_program.
-        :params prep_prog: Quil program for state preparation.
-        :params operators: (list) of PauliTerms. Default is Identity operator.
-        :returns: float expectation value of the operators.
+
+        :param Program prep_prog: Quil program for state preparation.
+        :param list operators: A list of PauliTerms. Default is Identity operator.
+        :returns: Expectation value of the operators.
+        :rtype: float
         """
         if not isinstance(prep_prog, pq.Program):
             raise TypeError("prep_prog variable must be a Quil program object")
@@ -382,8 +400,10 @@ class Connection(object):
     def bit_string_probabilities(self, quil_program):
         """
         Simulate a Quil program and get outcome probabilities back.
-        :param quil_program: A Quil program.
-        :return: A dict with outcomes as keys and probabilities as values.
+
+        :param Program quil_program: A Quil program.
+        :return: A dictionary with outcomes as keys and probabilities as values.
+        :rtype: dict
         """
         wvf, _ = self.wavefunction(quil_program)
         return get_outcome_probs(wvf)
@@ -392,11 +412,13 @@ class Connection(object):
         """
         Run a Quil program multiple times, accumulating the values deposited in
         a list of classical addresses.
-        :param quil_program: A Quil program.
-        :param classical_addresses: A list of addresses.
-        :param trials: Number of shots to collect.
+
+        :param Program quil_program: A Quil program.
+        :param list classical_addresses: A list of addresses.
+        :param int trials: Number of shots to collect.
         :return: A list of lists of bits. Each sublist corresponds to the values
-        in `classical_addresses`.
+                 in `classical_addresses`.
+        :rtype: list
         """
         if not isinstance(quil_program, pq.Program):
             raise TypeError("quil_program must be a Quil program object")
@@ -419,10 +441,12 @@ class Connection(object):
     def run_and_measure(self, quil_program, qubits, trials=1):
         """
         Run a Quil program once to determine the final wavefunction, and measure multiple times.
-        :param quil_program: A Quil program.
-        :param qubits: A list of qubits.
-        :param trials: Number of shots to collect.
+
+        :param Program quil_program: A Quil program.
+        :param list qubits: A list of qubits.
+        :param int trials: Number of shots to collect.
         :return: A list of a list of bits.
+        :rtype: list
         """
         if not isinstance(quil_program, pq.Program):
             raise TypeError("quil_program must be a Quil program object")
@@ -447,8 +471,10 @@ def get_outcome_probs(wvf):
     """
     Parses a wavefunction (array of complex amplitudes) and returns a dictionary of
     outcomes and associated probabilities.
-    :param wvf: A complex list of amplitudes.
+
+    :param list wvf: A complex list of amplitudes.
     :return: A dict with outcomes as keys and probabilities as values.
+    :rtype: dict
     """
     outcome_dict = {}
     qubit_num = len(wvf).bit_length() - 1

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -27,6 +27,7 @@ from pyquil.quilbase import Measurement, Gate, Addr, \
 def unpack_classical_reg(c):
     """
     Get the address for a classical register.
+
     :param c: A list of length 1 or an int or an Addr.
     :return: The address as an Addr.
     """
@@ -45,6 +46,7 @@ def unpack_classical_reg(c):
 def unpack_qubit(qubit):
     """
     Get a qubit from an object.
+
     :param qubit: An int or AbstractQubit.
     :return: An AbstractQubit instance
     """
@@ -170,6 +172,8 @@ PHASE = _make_gate("PHASE", 1, 1)
 """
 Produces a PHASE instruction. This is the same as the RZ gate.
 
+:param angle: The angle to rotate around the z-axis on the bloch sphere.
+:param qubit: The qubit apply the gate to.
 :returns: A Gate object.
 """
 

--- a/pyquil/parametric.py
+++ b/pyquil/parametric.py
@@ -31,6 +31,7 @@ def argument_count(thing):
 
     :param thing: A callable.
     :return: The number of arguments it takes.
+    :rtype: int
     """
     if not callable(thing):
         raise TypeError("should be callable")
@@ -60,6 +61,7 @@ class ParametricProgram(object):
 
         :param other: A Program or ParametricProgram.
         :return: A new ParametricProgram.
+        :rtype: ParametricProgram
         """
         r = copy(self)   # shallow copy the object
 
@@ -90,5 +92,6 @@ def parametric(decorated_function):
 
     :param decorated_function: The function taking parameters producing a Program object.
     :return: a callable ParametricProgram
+    :rtype: ParametricProgram
     """
     return ParametricProgram(decorated_function)

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -48,9 +48,9 @@ class PauliTerm(object):
         """ Create a new Pauli Term with a Pauli operator at a particular index and a leading
         coefficient.
 
-        :param op: The Pauli operator as a string "X", "Y", "Z", or "I"
-        :param index: (int) The qubit index that that operator is applied to.
-        :param coefficient: (float) The coefficient multiplying the operator, e.g. 1.5 * Z_1
+        :param string op: The Pauli operator as a string "X", "Y", "Z", or "I"
+        :param int index: The qubit index that that operator is applied to.
+        :param float coefficient: The coefficient multiplying the operator, e.g. 1.5 * Z_1
         """
         assert op in PAULI_OPS
         assert isinstance(index, int) and index >= 0
@@ -66,7 +66,9 @@ class PauliTerm(object):
         """
         Returns the unique identifier string for the PauliTerm.  Used in the
         simplify method of PauliSum.
-        :return: (string) The unique identifier for this term.
+
+        :return: The unique identifier for this term.
+        :rtype: string
         """
         if self._id is not None:
             return self._id
@@ -118,7 +120,6 @@ class PauliTerm(object):
         """Multiplies this Pauli Term with another PauliTerm, PauliSum, or number according to the Pauli algebra rules.
 
         :param term: (PauliTerm or PauliSum or Number) A term to multiply by.
-
         :returns: The product of this PauliTerm and term.
         """
         if isinstance(term, Number):
@@ -137,18 +138,19 @@ class PauliTerm(object):
     def __rmul__(self, other):
         """Multiplies this PauliTerm with another object, probably a number.
 
-        :param term: (Number) A number to multiply by.
-
-        :returns: A new PauliTerm."""
+        :param Number term: A number to multiply by
+        :returns: A new PauliTerm
+        :rtype: PauliTerm
+        """
         assert isinstance(other, Number)
         return self * other
 
     def __add__(self, term):
         """Adds this PauliTerm with another one.
 
-        :param term: (PauliTerm)
-
-        :returns: A PauliSum object representing the sum of this PauliTerm and term.
+        :param PauliTerm term: A PauliTerm object
+        :returns: A PauliSum object representing the sum of this PauliTerm and term
+        :rtype: PauliSum
         """
         if isinstance(term, Number):
             return self + PauliTerm("I", 0, term)
@@ -161,9 +163,10 @@ class PauliTerm(object):
     def __radd__(self, term):
         """Adds this PauliTerm with a Number.
 
-        :param term: (Number) A number to multiply by.
-
-        :returns: A new PauliTerm"""
+        :param Number term: A number to multiply by
+        :returns: A new PauliTerm
+        :rtype: PauliTerm
+        """
         assert isinstance(term, Number)
         return self + term
 
@@ -187,29 +190,33 @@ sI = lambda q: PauliTerm("I", q)
 """
 A function that returns the identity operator on a particular qubit.
 
-:param qubit_index: (int)
-:returns: A PauliTerm
+:param int qubit_index: The index of the qubit
+:returns: A PauliTerm object
+:rtype: PauliTerm
 """
 sX = lambda q: PauliTerm("X", q)
 """
 A function that returns the sigma_X operator on a particular qubit.
 
-:param qubit_index: (int)
-:returns: A PauliTerm
+:param int qubit_index: The index of the qubit
+:returns: A PauliTerm object
+:rtype: PauliTerm
 """
 sY = lambda q: PauliTerm("Y", q)
 """
 A function that returns the sigma_Y operator on a particular qubit.
 
-:param qubit_index: (int)
-:returns: A PauliTerm
+:param int qubit_index: The index of the qubit
+:returns: A PauliTerm object
+:rtype: PauliTerm
 """
 sZ = lambda q: PauliTerm("Z", q)
 """
 A function that returns the sigma_Z operator on a particular qubit.
 
-:param qubit_index: (int)
-:returns: A PauliTerm
+:param int qubit_index: The index of the qubit
+:returns: A PauliTerm object
+:rtype: PauliTerm
 """
 
 
@@ -217,10 +224,10 @@ def term_with_coeff(term, coeff):
     """
     Change the coefficient of a PauliTerm.
 
-    :param term: (PauliTerm)
-    :param coeff: (float) the coefficient to set on the PauliTerm
-
-    :returns: (PauliTerm) A new PauliTerm that duplicates term but sets coeff
+    :param PauliTerm term: A PauliTerm object
+    :param float coeff: The coefficient to set on the PauliTerm
+    :returns: A new PauliTerm that duplicates term but sets coeff
+    :rtype: PauliTerm
     """
     new_pauli = copy.copy(term)
     new_pauli.coefficient = coeff
@@ -233,7 +240,7 @@ class PauliSum(object):
 
     def __init__(self, terms):
         """
-        :param terms: A list of PauliTerms.
+        :param list terms: A list of PauliTerms.
         """
         if len(terms) == 0:
             self.terms = [0.0 * ID]
@@ -279,7 +286,8 @@ class PauliSum(object):
         """
         The support of all the operators in the PauliSum object.
 
-        :returns: (list) A list of all the qubits in the sum of terms.
+        :returns: A list of all the qubits in the sum of terms.
+        :rtype: list
         """
         return list(set().union(*[term.get_qubits() for term in self.terms]))
 
@@ -316,9 +324,10 @@ def check_commutation(pauli_list, pauli_two):
     Derivation similar to arXiv:1405.5749v2 fo the check_commutation step in
     the Raesi, Wiebe, Sanders algorithm (arXiv:1108.4318, 2011).
 
-    :param pauli_list: (list) of PauliTerm objects.
-    :param pauli_two_term: (PauliTerm) object.
-    :returns: (bool) true false if pauli_two object commutes with pauli_list.
+    :param list pauli_list: A list of PauliTerm objects
+    :param PauliTerm pauli_two_term: A PauliTerm object
+    :returns: True if pauli_two object commutes with pauli_list, False otherwise
+    :rtype: bool
     """
     def coincident_parity(p1, p2):
         non_similar = 0
@@ -341,8 +350,9 @@ def commuting_sets(pauli_terms, nqubits):
     Uses algorithm defined in (Raeisi, Wiebe, Sanders, arXiv:1108.4318, 2011)
     to find commuting sets. Except uses commutation check from arXiv:1405.5749v2
 
-    :param pauli_terms: (PauliSum) object.
-    :returns: (list) of lists where each list contains a commuting set
+    :param PauliSum pauli_terms: A PauliSum object
+    :returns: List of lists where each list contains a commuting set
+    :rtype: list
     """
 
     m_terms = len(pauli_terms.terms)
@@ -367,8 +377,9 @@ def is_identity(term):
     """
     Check if Pauli Term is a scalar multiple of identity
 
-    :param term: (PauliTerm) Tests is a PauliTerm is the identity operator
-    :returns: (bool)
+    :param PauliTerm term: A PauliTerm object
+    :returns: True if the PauliTerm is a scalar multiple of identity, false otherwise
+    :rtype: bool
     """
     return len(term) == 0
 
@@ -377,8 +388,8 @@ def exponentiate(term):
     """
     Creates a pyQuil program that simulates the unitary evolution exp(-1j * term)
 
-    :param term: (PauliTerm) Tests is a PauliTerm is the identity operator
-    :returns: (Program)
+    :param PauliTerm term: Tests is a PauliTerm is the identity operator
+    :returns: A Program object
     """
     return exponential_map(term)(1.0)
 
@@ -387,8 +398,9 @@ def exponential_map(term):
     """
     Creates map alpha -> exp(-1j*alpha*term) represented as a ParametricProgram.
 
-    :param term: (PauliTerm) Tests is a PauliTerm is the identity operator
-    :returns: (ParametricProgram)
+    :param PauliTerm term: Tests is a PauliTerm is the identity operator
+    :returns: A ParametricProgram
+    :rtype: ParametricProgram
     """
     if not np.isclose(np.imag(term.coefficient), 0.0):
         raise TypeError("PauliTerm coefficient must be real")
@@ -415,9 +427,8 @@ def _exponentiate_general_case(pauli_term, param):
     Returns a Quil (Program()) object corresponding to the exponential of
     the pauli_term object, i.e. exp[-1.0j * param * pauli_term]
 
-    :param pauli_term: (PauliTerm) to exponentiate
+    :param PauliTerm pauli_term: A PauliTerm to exponentiate
     :param param: scalar, non-complex, value
-
     :returns: A Quil (Program()) object
     """
     def reverse_hack(p):
@@ -483,8 +494,9 @@ def suzuki_trotter(trotter_order, trotter_steps):
 
     :param trotter_order: order of Suzuki-Trotter approximation
     :param trotter_steps: number of steps in the approximation
-    :returns: (list) of tuples corresponding to the coefficient and operator
+    :returns: List of tuples corresponding to the coefficient and operator
               type: o=0 is A and o=1 is B.
+    :rtype: list
     """
     p1 = p2 = p4 = p5 = 1.0/(4 - (4**(1./3)))
     p3 = 1 - 4 * p1
@@ -507,9 +519,11 @@ def suzuki_trotter(trotter_order, trotter_steps):
 
 def is_zero(pauli_object):
     """
-    Tests to see if a PauliTerm of PauliSum is zero.
+    Tests to see if a PauliTerm or PauliSum is zero.
+
     :param pauli_object: Either a PauliTerm or PauliSum
-    :returns: (Boolean)
+    :returns: True if PauliTerm is zero, False otherwise
+    :rtype: bool
     """
     if isinstance(pauli_object, PauliTerm):
         if pauli_object.id() == '':

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -121,6 +121,7 @@ class PauliTerm(object):
 
         :param term: (PauliTerm or PauliSum or Number) A term to multiply by.
         :returns: The product of this PauliTerm and term.
+        :rtype: PauliTerm
         """
         if isinstance(term, Number):
             return term_with_coeff(self, self.coefficient * term)
@@ -390,6 +391,7 @@ def exponentiate(term):
 
     :param PauliTerm term: Tests is a PauliTerm is the identity operator
     :returns: A Program object
+    :rtype: Program
     """
     return exponential_map(term)(1.0)
 
@@ -428,8 +430,9 @@ def _exponentiate_general_case(pauli_term, param):
     the pauli_term object, i.e. exp[-1.0j * param * pauli_term]
 
     :param PauliTerm pauli_term: A PauliTerm to exponentiate
-    :param param: scalar, non-complex, value
-    :returns: A Quil (Program()) object
+    :param float param: scalar, non-complex, value
+    :returns: A Quil program object
+    :rtype: Program
     """
     def reverse_hack(p):
         # A hack to produce a *temporary* program which reverses p.
@@ -492,8 +495,8 @@ def suzuki_trotter(trotter_order, trotter_steps):
     [(0.5/trotter_steps, 0), (1/trotteri_steps, 1),
     (0.5/trotter_steps, 0)] * trotter_steps.
 
-    :param trotter_order: order of Suzuki-Trotter approximation
-    :param trotter_steps: number of steps in the approximation
+    :param int trotter_order: order of Suzuki-Trotter approximation
+    :param int trotter_steps: number of steps in the approximation
     :returns: List of tuples corresponding to the coefficient and operator
               type: o=0 is A and o=1 is B.
     :rtype: list
@@ -545,14 +548,15 @@ def trotterize(first_pauli_term, second_pauli_term, trotter_order=1,
     Create a Quil program that approximates exp( (A + B)t) where A and B are
     PauliTerm operators.
 
-    :param first_pauli_term: PauliTerm denoted `A`
-    :param second_pauli_term: PauliTerm denoted `B`
-    :param trotter_order: Optional argument indicating the Suzuki-Trotter
+    :param PauliTerm first_pauli_term: PauliTerm denoted `A`
+    :param PauliTerm second_pauli_term: PauliTerm denoted `B`
+    :param int trotter_order: Optional argument indicating the Suzuki-Trotter
                           approximation order--only accepts orders 1, 2, 3, 4.
-    :param trotter_steps: Optional argument indicating the number of products
+    :param int trotter_steps: Optional argument indicating the number of products
                           to decompose the exponential into.
 
     :return: Quil program
+    :rtype: Program
     """
 
     if not (1 <= trotter_order < 5):

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -44,8 +44,9 @@ class Program(InstructionGroup):
         """
         Concatenate two programs together, returning a new one.
 
-        :param other: Another program or instruction to concatenate to this one.
+        :param Program other: Another program or instruction to concatenate to this one.
         :return: A newly concatenated program.
+        :rtype: Program
         """
         if isinstance(other, Program):
             p = Program()
@@ -64,6 +65,7 @@ class Program(InstructionGroup):
         :param string name: The name of the gate.
         :param array-like matrix: List of lists or Numpy 2d array.
         :return: The Program instance.
+        :rtype: Program
         """
         self.defined_gates.append(DefGate(name, matrix))
         return self

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -61,8 +61,8 @@ class Program(InstructionGroup):
         """
         Define a new static gate.
 
-        :param name: (int) The name of the gate (str).
-        :param matrix: List of lists or Numpy 2d array.
+        :param string name: The name of the gate.
+        :param array-like matrix: List of lists or Numpy 2d array.
         :return: The Program instance.
         """
         self.defined_gates.append(DefGate(name, matrix))
@@ -72,11 +72,11 @@ class Program(InstructionGroup):
         """
         Measures a qubit at qubit_index and puts the result in classical_reg
 
-        :param qubit_index: (int) The address of the qubit to measure.
-        :param classical_reg: (int) The address of the classical bit to store the result.
-
+        :param int qubit_index: The address of the qubit to measure.
+        :param int classical_reg: The address of the classical bit to store the result.
         :returns: The Quil Program with the appropriate measure instruction appended, e.g.
                   MEASURE 0 [1]
+        :rtype: Program
         """
         return self.inst(MEASURE(qubit_index, classical_reg))
 
@@ -84,10 +84,10 @@ class Program(InstructionGroup):
         """
         While a classical register at index classical_reg is 1, loop q_program
 
-        :param classical_reg: (int) The classical register to check
-        :param q_program: (Program) The Quil program to loop.
-
+        :param int classical_reg: The classical register to check
+        :param Program q_program: The Quil program to loop.
         :return: The Quil Program with the loop instructions added.
+        :rtype: Program
         """
         w_loop = While(Addr(classical_reg))
         w_loop.Body.inst(q_program)
@@ -98,12 +98,12 @@ class Program(InstructionGroup):
         If the classical register at index classical reg is 1, run if_program, else run
         else_program.
 
-        :param classical_reg: (int) The classical register to check as the condition
-        :param if_program: (Program) A Quil program to execute if classical_reg is 1
-        :param else_program: (Program) A Quil program to execute if classical_reg is 0. This
+        :param int classical_reg: The classical register to check as the condition
+        :param Program if_program: A Quil program to execute if classical_reg is 1
+        :param Program else_program: A Quil program to execute if classical_reg is 0. This
             argument is optional and defaults to an empty Program.
-
         :returns: The Quil Program with the branching instructions added.
+        :rtype: Program
         """
 
         else_program = else_program if else_program is not None else Program()
@@ -116,7 +116,9 @@ class Program(InstructionGroup):
     def out(self):
         """
         Converts the Quil program to a readable string.
-        :return: (string)
+
+        :return: String form of a program
+        :rtype: string
         """
         s = ""
         for dg in self.defined_gates:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -58,7 +58,7 @@ def format_matrix_element(element):
     """
     Formats a parameterized matrix element.
 
-    :param: {int, long, float, complex, str} The parameterized element to format.
+    :param element: {int, long, float, complex, str} The parameterized element to format.
     """
     if isinstance(element, (int, long, float, complex)):
         return format_parameter(element)
@@ -72,7 +72,7 @@ def format_parameter(element):
     """
     Formats a particular parameter.
 
-    :param: {int, float, long, complex, Slot} Formats a parameter for Quil output.
+    :param element: {int, float, long, complex, Slot} Formats a parameter for Quil output.
     """
     if isinstance(element, (int, float)):
         return repr(element)
@@ -94,7 +94,7 @@ class Addr(QuilAtom):
     """
     Representation of a classical bit address.
 
-    :param value: (int) The classical address.
+    :param int value: The classical address.
     """
 
     def __init__(self, value):
@@ -113,7 +113,7 @@ class Label(QuilAtom):
     """
     Representation of a label.
 
-    :param label_name: (string) The label name.
+    :param string label_name: The label name.
     """
 
     def __init__(self, label_name):
@@ -152,8 +152,8 @@ class DefGate(AbstractInstruction):
     """
     A DEFGATE directive.
 
-    :param name: (string) the name of the newly defined gate.
-    :param matrix: {list, nparray, np.matrix} The matrix defining this gate.
+    :param string name: The name of the newly defined gate.
+    :param array-like matrix: {list, nparray, np.matrix} The matrix defining this gate.
     """
 
     def __init__(self, name, matrix):
@@ -178,7 +178,8 @@ class DefGate(AbstractInstruction):
         """
         Prints a readable Quil string representation of this gate.
 
-        :returns: (string)
+        :returns: String representation of a gate
+        :rtype: string
         """
         result = "DEFGATE %s:\n" % (self.name)
         for row in self.matrix:
@@ -198,6 +199,7 @@ class DefGate(AbstractInstruction):
     def num_args(self):
         """
         :return: The number of qubit arguments the gate takes.
+        :rtype: int
         """
         rows = len(self.matrix)
         return int(np.log2(rows))
@@ -242,7 +244,9 @@ class InstructionGroup(QuilAction):
     def alloc(self):
         """
         Get a new qubit.
+
         :return: A qubit.
+        :rtype: Qubit
         """
         qubit = self.resource_manager.allocate_qubit()
         self.actions.append(action(ACTION_INSTANTIATE_QUBIT, qubit))
@@ -252,7 +256,8 @@ class InstructionGroup(QuilAction):
     def free(self, qubit):
         """
         Free a qubit.
-        :param q: An AbstractQubit instance
+
+        :param AbstractQubit q: An AbstractQubit instance
         """
         check_live_qubit(qubit)
 
@@ -517,8 +522,10 @@ def reset_label_counter():
 def gen_label(prefix="L"):
     """
     Generate a fresh label.
-    :param prefix: An optional prefix for the label name
+
+    :param string prefix: An optional prefix for the label name
     :return: A new Label instance.
+    :rtype: Label
     """
     global label_counter
     label_counter += 1
@@ -601,7 +608,8 @@ class Instr(AbstractInstruction):
     def make_qubits_known(self, rm):
         """
         Make the qubits involved with this instruction known to a ResourceManager.
-        :param rm: A ResourceManager.
+
+        :param ResourceManager rm: A ResourceManager object.
         """
         if not isinstance(rm, ResourceManager):
             raise TypeError("rm should be a ResourceManager")
@@ -617,7 +625,9 @@ class Instr(AbstractInstruction):
     def qubits(self):
         """
         The qubits this instruction affects.
+
         :return: Set of qubit indexes.
+        :rtype: set
         """
         qubits = set()
         for arg in self.arguments:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -257,7 +257,7 @@ class InstructionGroup(QuilAction):
         """
         Free a qubit.
 
-        :param AbstractQubit q: An AbstractQubit instance
+        :param AbstractQubit q: An AbstractQubit instance.
         """
         check_live_qubit(qubit)
 
@@ -308,6 +308,7 @@ class InstructionGroup(QuilAction):
         Pops off the last instruction.
 
         :return: The (action, instruction) pair for the instruction that was popped.
+        :rtype: tuple
         """
         if 0 != len(self.actions):
             return self.actions.pop()
@@ -315,6 +316,8 @@ class InstructionGroup(QuilAction):
     def extract_qubits(self):
         """
         Return all qubit addresses involved in the instruction group.
+        :return: Set of qubits.
+        :rtype: set
         """
         qubits = set()
         for jj, act_jj in self.actions:
@@ -523,7 +526,7 @@ def gen_label(prefix="L"):
     """
     Generate a fresh label.
 
-    :param string prefix: An optional prefix for the label name
+    :param string prefix: An optional prefix for the label name.
     :return: A new Label instance.
     :rtype: Label
     """

--- a/pyquil/resource_manager.py
+++ b/pyquil/resource_manager.py
@@ -69,7 +69,8 @@ class Qubit(AbstractQubit):
 
     def index(self):
         """
-        :returns: (int) The index of this qubit.
+        :returns: The index of this qubit.
+        :rtype: int
         """
         if not instantiated(self):
             raise RuntimeError("Can't get the index of an unassigned qubit.")
@@ -101,8 +102,9 @@ def instantiated(qubit):
     """
     Is the qubit instantiated?
 
-    :param qubit: A AbstractQubit instance.
+    :param AbstractQubit qubit: A AbstractQubit instance.
     :return: A boolean.
+    :rtype: bool
     """
     return qubit.assignment is not None
 
@@ -128,7 +130,9 @@ class ResourceManager(object):
     def allocate_qubit(self):
         """
         Create a new Qubit object.
+
         :return: A Qubit instance.
+        :rtype: Qubit
         """
         new_q = Qubit(self)
         self.live_qubits.append(new_q)
@@ -137,7 +141,8 @@ class ResourceManager(object):
     def free_qubit(self, q):
         """
         Free the previously allocated qubit.
-        :param q: A live Qubit that was previously allocated.
+
+        :param Qubit q: A live Qubit that was previously allocated.
         """
         if q not in self.live_qubits:
             raise RuntimeError("Qubit {} is not part of the ResourceManager".format(q))
@@ -148,7 +153,8 @@ class ResourceManager(object):
     def instantiate(self, qubit):
         """
         Assign a number to a qubit.
-        :param qubit: A Qubit object.
+
+        :param Qubit qubit: A Qubit object.
         """
 
         def find_available_qubit(d):
@@ -166,7 +172,8 @@ class ResourceManager(object):
     def uninstantiate_index(self, i):
         """
         Free up an index that was previously instantiated.
-        :param i: The index.
+
+        :param int i: The index.
         """
         q = self.in_use.get(i, False)
         if q and isinstance(q, Qubit):
@@ -177,9 +184,11 @@ def merge_resource_managers(rm1, rm2):
     """
     Merge two resource managers into a new resource manager. All qubits in the old managers will
     point to the new one. The in_use labels of the second resource manager have priority.
-    :param rm1: A ResourceManager.
-    :param rm2: A ResourceManager.
+
+    :param ResourceManager rm1: A ResourceManager.
+    :param ResourceManager rm2: A ResourceManager.
     :return: A merged ResourceManager.
+    :rtype: ResourceManager
     """
     rm = ResourceManager()
     rm.live_qubits = rm1.live_qubits + rm2.live_qubits

--- a/pyquil/slot.py
+++ b/pyquil/slot.py
@@ -26,8 +26,8 @@ class Slot(object):
     Logical: abs, max, <, >, <=, >=, !=, ==
     Arbitrary functions are not supported
 
-    :param value: (float) A value to initialize to. Defaults to 0.0
-    :param func: (function) An initial function to determine the final parameterized value.
+    :param float value: A value to initialize to. Defaults to 0.0
+    :param function func: An initial function to determine the final parameterized value.
     """
 
     def __init__(self, value=0.0, func=None):


### PR DESCRIPTION
Sphinx-style docstrings require a newline between the description section and the parameters/return value section of the docstrings for correct rendering. Also, parameter docstrings will correctly interpret types if they are in the form `:param param-type param-name: param-description` and return value docstrings can be typed by including an `:rtype: return-type` tag.