### PR TITLE
DefGate: validation for unitary matrix 

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -174,6 +174,11 @@ class DefGate(AbstractInstruction):
         self.name = name
         self.matrix = np.asarray(matrix)
 
+        is_unitary = np.allclose(np.eye(rows), self.matrix.dot(self.matrix.T.conj()))
+        if not is_unitary:
+            raise AssertionError("Matrix must be unitary.")
+
+
     def out(self):
         """
         Prints a readable Quil string representation of this gate.

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -40,11 +40,9 @@ def test_gate():
 
 
 def test_defgate():
-    dg = DefGate("TEST", np.array([[sqrt(0.5), sqrt(0.5)],
-                                   [-sqrt(0.5) * 1j, sqrt(0.5) * 1j]]))
-    assert dg.out() == "DEFGATE TEST:" \
-                       "\n    0.70710678118654757+0.0i, 0.70710678118654757+0.0i"\
-                       "\n    -0.0-0.70710678118654757i, 0.0+0.70710678118654757i\n"
+    dg = DefGate("TEST", np.array([[1., 0.],
+                                   [0., 1.]]))
+    assert dg.out() == "DEFGATE TEST:\n    1.0, 0.0\n    0.0, 1.0\n"
     test = dg.get_constructor()
     tg = test(DirectQubit(1), DirectQubit(2))
     assert tg.out() == "TEST 1 2"
@@ -53,7 +51,7 @@ def test_defgate():
 def test_defgate_non_square_should_throw_error():
     with pytest.raises(AssertionError) as error_info:
         DefGate("TEST", np.array([[0 + 0.5j, 0.5, 1],
-                                   [0.5, 0 - 0.5j, 1]]))
+                                  [0.5, 0 - 0.5j, 1]]))
     assert str(error_info.value) == "Matrix must be square."
 
 

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -193,7 +193,7 @@ def test_rotations():
     assert p.out() == 'RX(0.5) 0\nRY(0.1) 1\nRZ(1.4) 2\n'
 
 
-def test_contolled_gates():
+def test_controlled_gates():
     p = Program(CNOT(0, 1), CCNOT(0, 1, 2))
     assert p.out() == 'CNOT 0 1\nCCNOT 0 1 2\n'
 

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -23,9 +23,11 @@ from pyquil.gates import I, X, Y, Z, H, T, S, RX, RY, RZ, CNOT, CCNOT, PHASE, CP
     TRUE, FALSE, NOT, AND, OR, MOVE, EXCHANGE
 from pyquil.quilbase import InstructionGroup, DefGate, Gate, reset_label_counter, RawInstr, Addr
 
+import pytest
+
 import numpy as np
 from scipy.linalg import sqrtm
-from math import pi
+from math import pi, sqrt
 
 
 def test_make_connection():
@@ -38,17 +40,33 @@ def test_gate():
 
 
 def test_defgate():
-    dg = DefGate("TEST", np.array([[0 + 0.5j, 0.5],
-                                   [0.5, 0 - 0.5j]]))
-    assert dg.out() == "DEFGATE TEST:\n    0.0+0.5i, 0.5+0.0i\n    0.5+0.0i, 0.0-0.5i\n"
+    dg = DefGate("TEST", np.array([[sqrt(0.5), sqrt(0.5)],
+                                   [-sqrt(0.5) * 1j, sqrt(0.5) * 1j]]))
+    assert dg.out() == "DEFGATE TEST:" \
+                       "\n    0.70710678118654757+0.0i, 0.70710678118654757+0.0i"\
+                       "\n    -0.0-0.70710678118654757i, 0.0+0.70710678118654757i\n"
     test = dg.get_constructor()
     tg = test(DirectQubit(1), DirectQubit(2))
     assert tg.out() == "TEST 1 2"
 
 
+def test_defgate_non_square_should_throw_error():
+    with pytest.raises(AssertionError) as error_info:
+        DefGate("TEST", np.array([[0 + 0.5j, 0.5, 1],
+                                   [0.5, 0 - 0.5j, 1]]))
+    assert str(error_info.value) == "Matrix must be square."
+
+
+def test_defgate_non_unitary_should_throw_error():
+    with pytest.raises(AssertionError) as error_info:
+        DefGate("TEST", np.array([[0, 1],
+                                  [2, 3]]))
+    assert str(error_info.value) == "Matrix must be unitary."
+
+
 def test_defgate_param():
-    dgp = DefGate("TEST", [[1., 1.], [0., 1.]])
-    assert dgp.out() == "DEFGATE TEST:\n    1.0, 1.0\n    0.0, 1.0\n"
+    dgp = DefGate("TEST", [[1., 0.], [0., 1.]])
+    assert dgp.out() == "DEFGATE TEST:\n    1.0, 0.0\n    0.0, 1.0\n"
     test = dgp.get_constructor()
     tg = test(DirectQubit(1))
     assert tg.out() == "TEST 1"


### PR DESCRIPTION
Based on the discussion on https://github.com/rigetticomputing/pyquil/issues/20 I implemented the unitary check. 