### PR TITLE
Remove scipy dep and small code clean up

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -406,11 +406,11 @@ matrix representation of the gate. For example, below we define a
 .. code:: python
 
     import numpy as np
-    from scipy.linalg import sqrtm
 
     # First we define the new gate from a matrix
     x_gate_matrix = np.array(([0.0, 1.0], [1.0, 0.0]))
-    sqrt_x = sqrtm(x_gate_matrix)
+    sqrt_x = np.array([[ 0.5+0.5j,  0.5-0.5j],
+                       [ 0.5-0.5j,  0.5+0.5j]])
     p = pq.Program().defgate("SQRT-X", sqrt_x)
 
     # Then we can use the new gate,
@@ -443,18 +443,20 @@ matrix representation of the gate. For example, below we define a
 
 Quil in general supports defining parametric gates, though right now
 only static gates are supported by pyQuil. Below we show how we can
-define :math:`X_1\otimes \sqrt{X_0}` as a single
+define :math:`X_0\otimes \sqrt{X_1}` as a single
 gate.
 
 .. code:: python
 
     # A multi-qubit defgate example
     x_gate_matrix = np.array(([0.0, 1.0], [1.0, 0.0]))
-    x_sqrt_x = np.kron(sqrtm(x_gate_matrix), x_gate_matrix)
+    sqrt_x = np.array([[ 0.5+0.5j,  0.5-0.5j],
+                       [ 0.5-0.5j,  0.5+0.5j]])
+    x_sqrt_x = np.kron(x_gate_matrix, sqrt_x)
     p = pq.Program().defgate("X-SQRT-X", x_sqrt_x)
 
     # Then we can use the new gate
-    p.inst(("X-SQRT-X", 1, 0))
+    p.inst(("X-SQRT-X", 0, 1))
     wavf, _ = qvm.wavefunction(p)
     print wavf
 

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -121,22 +121,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<pyquil.quil.Program at 0x7f7ce3466c50>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = pq.Program()\n",
     "p.inst(X(0)).measure(0, 0)"
@@ -151,21 +140,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X 0\n",
-      "MEASURE 0 [0]\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print p"
    ]
@@ -179,22 +158,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[[1]]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "classical_regs = [0] # A list of which classical registers to return the values of.\n",
     "\n",
@@ -210,22 +178,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[[1, 0, 0]]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qvm.run(p, [0, 1, 2])"
    ]
@@ -239,22 +196,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[[0, 1, 0]]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = pq.Program()   # clear the old program\n",
     "p.inst(X(0)).measure(0, 1)\n",
@@ -270,22 +216,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[[0], [0], [1], [0], [1]]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "coin_flip = pq.Program().inst(H(0)).measure(0, 0)\n",
     "num_flips = 5\n",
@@ -303,22 +238,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([ 0.70710678+0.j,  0.70710678+0.j]), [])"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "coin_flip = pq.Program().inst(H(0))\n",
     "qvm.wavefunction(coin_flip)"
@@ -342,41 +266,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Multiple inst arguments with final measurement:\n",
-      "X 0\n",
-      "Y 1\n",
-      "Z 0\n",
-      "MEASURE 0 [1]\n",
-      "\n",
-      "Chained inst with explicit MEASURE instruction:\n",
-      "X 0\n",
-      "Y 1\n",
-      "MEASURE 0 [1]\n",
-      "MEASURE 1 [2]\n",
-      "\n",
-      "A mix of chained inst and measures:\n",
-      "X 0\n",
-      "MEASURE 0 [1]\n",
-      "Y 1\n",
-      "X 0\n",
-      "MEASURE 0 [0]\n",
-      "\n",
-      "A composition of two programs:\n",
-      "X 0\n",
-      "Y 0\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print \"Multiple inst arguments with final measurement:\"\n",
     "print pq.Program().inst(X(0), Y(1), Z(0)).measure(0, 1)\n",
@@ -402,29 +296,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Oops! We have added Y 1 by accident:\n",
-      "X 0\n",
-      "Y 1\n",
-      "\n",
-      "We can fix by popping:\n",
-      "X 0\n",
-      "\n",
-      "And then add it back:\n",
-      "X 0\n",
-      "Y 1\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = pq.Program().inst(X(0))\n",
     "p.inst(Y(1))\n",
@@ -477,31 +353,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEFGATE SQRT-X:\n",
-      "    0.49999999999999989+0.49999999999999989i, 0.49999999999999989-0.49999999999999989i\n",
-      "    0.49999999999999989-0.49999999999999989i, 0.49999999999999989+0.49999999999999989i\n",
-      "\n",
-      "SQRT-X 0\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from scipy.linalg import sqrtm\n",
     "\n",
     "# First we define the new gate from a matrix\n",
     "x_gate_matrix = np.array(([0.0, 1.0], [1.0, 0.0]))\n",
-    "sqrt_x = sqrtm(x_gate_matrix)\n",
+    "sqrt_x = np.array([[ 0.5+0.5j,  0.5-0.5j],\n",
+    "                   [ 0.5-0.5j,  0.5+0.5j]])\n",
     "p = pq.Program().defgate(\"SQRT-X\", sqrt_x)\n",
     "\n",
     "# Then we can use the new gate,\n",
@@ -511,22 +374,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([ 0.5+0.5j,  0.5-0.5j]), [])"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qvm.wavefunction(p)"
    ]
@@ -540,30 +392,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([ 0.0+0.j ,  0.5+0.5j,  0.0+0.j ,  0.5-0.5j]), [])"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# A multi-qubit defgate example\n",
     "x_gate_matrix = np.array(([0.0, 1.0], [1.0, 0.0]))\n",
-    "x_sqrt_x = np.kron(sqrtm(x_gate_matrix), x_gate_matrix)\n",
+    "sqrt_x = np.array([[ 0.5+0.5j,  0.5-0.5j],\n",
+    "                [ 0.5-0.5j,  0.5+0.5j]])\n",
+    "x_sqrt_x = np.kron(x_gate_matrix, sqrt_x)\n",
     "p = pq.Program().defgate(\"X-SQRT-X\", x_sqrt_x)\n",
     "\n",
     "# Then we can use the new gate\n",
-    "p.inst((\"X-SQRT-X\", 1, 0))\n",
+    "p.inst((\"X-SQRT-X\", 0, 1))\n",
     "qvm.wavefunction(p)"
    ]
   },
@@ -593,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -624,26 +467,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "H 2\n",
-      "CPHASE(1.5707963267948966) 1 2\n",
-      "H 1\n",
-      "CPHASE(0.7853981633974483) 0 2\n",
-      "CPHASE(1.5707963267948966) 0 1\n",
-      "H 0\n",
-      "SWAP 0 2\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print qft3(0, 1, 2)"
    ]
@@ -657,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -675,22 +503,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([ 0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j]), [])"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "add_dummy_qubits = pq.Program().inst(I(2))\n",
     "qvm.wavefunction(state_prep + add_dummy_qubits)"
@@ -705,26 +522,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([  3.53553391e-01+0.j        ,   2.50000000e-01+0.25j      ,\n",
-       "          2.16489014e-17+0.35355339j,  -2.50000000e-01+0.25j      ,\n",
-       "         -3.53553391e-01+0.j        ,  -2.50000000e-01-0.25j      ,\n",
-       "         -2.16489014e-17-0.35355339j,   2.50000000e-01-0.25j      ]), [])"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qvm.wavefunction(state_prep + qft3(0, 1, 2))"
    ]
@@ -738,25 +541,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 0.35355339+0.j        ,  0.25000000+0.25j      ,\n",
-       "        0.00000000+0.35355339j, -0.25000000+0.25j      ,\n",
-       "       -0.35355339+0.j        , -0.25000000-0.25j      ,\n",
-       "        0.00000000-0.35355339j,  0.25000000-0.25j      ])"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from numpy.fft import ifft\n",
     "ifft([0,1,0,0,0,0,0,0], norm=\"ortho\")"
@@ -779,27 +568,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TRUE [2]\n",
-      "LABEL @START1\n",
-      "JUMP-UNLESS @END2 [2]\n",
-      "X 0\n",
-      "H 0\n",
-      "MEASURE 0 [2]\n",
-      "JUMP @START1\n",
-      "LABEL @END2\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Name our classical registers:\n",
     "classical_flag_register = 2\n",
@@ -833,27 +606,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "H 1\n",
-      "MEASURE 1 [1]\n",
-      "JUMP-WHEN @THEN3 [1]\n",
-      "JUMP @END4\n",
-      "LABEL @THEN3\n",
-      "X 0\n",
-      "LABEL @END4\n",
-      "MEASURE 0 [0]\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Name our classical registers:\n",
     "test_register = 1\n",
@@ -885,22 +642,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[[1], [1], [0], [1], [0], [0], [0], [0], [1], [0]]"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qvm.run(branching_prog, [answer_register], 10)"
    ]
@@ -921,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -942,20 +688,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Without Noise: [[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]\n",
-      "With Noise   : [[1], [1], [1], [1], [1], [0], [1], [0], [1], [1]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = pq.Program().inst(X(0)).measure(0, 0)\n",
     "print \"Without Noise:\", qvm.run(p, [0], 10)\n",
@@ -973,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -996,20 +733,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RX(0.5) 0\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print par_p(0.5)"
    ]
@@ -1032,19 +760,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sigma = 0.5*I + -0.75*X0*Y1*Z3 + (5-2j)*Z1*X2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyquil.paulis import ID, sX, sY, sZ\n",
     "\n",
@@ -1076,25 +796,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Simplified  : (32.46875-30j)*I + (-16.734375+15j)*X0*Y1*Z3 + (71.5625-144.625j)*Z1*X2\n",
-      "\n",
-      "Quil to compute exp[iX] on qubit 0:\n",
-      "H 0\n",
-      "RZ(-2.0) 0\n",
-      "H 0\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pyquil.paulis as pl\n",
     "\n",

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -26,7 +26,6 @@ from pyquil.quilbase import InstructionGroup, DefGate, Gate, reset_label_counter
 import pytest
 
 import numpy as np
-from scipy.linalg import sqrtm
 from math import pi, sqrt
 
 
@@ -231,35 +230,29 @@ def test_swaps():
 def test_def_gate():
     # First we define the new gate from a matrix
     x_gate_matrix = np.array(([0.0, 1.0], [1.0, 0.0]))
-    sqrt_x = sqrtm(x_gate_matrix)
+    sqrt_x = np.array([[ 0.5+0.5j,  0.5-0.5j],
+                       [ 0.5-0.5j,  0.5+0.5j]])
     p = Program().defgate("SQRT-X", sqrt_x)
 
     # Then we can use the new gate
     p.inst(("SQRT-X", 0))
-    assert p.out() == 'DEFGATE SQRT-X:\n    0.49999999999999989+0.49999999999999989i, ' \
-                      '0.49999999999999989-0.49999999999999989i\n    ' \
-                      '0.49999999999999989-0.49999999999999989i, 0.49999999999999989+' \
-                      '0.49999999999999989i\n\nSQRT-X 0\n'
-
+    assert p.out() == 'DEFGATE SQRT-X:\n    0.5+0.5i, 0.5-0.5i\n    0.5-0.5i, 0.5+0.5i\n\nSQRT-X 0\n'
 
 def test_multiqubit_gate():
     # A multi-qubit defgate example
     x_gate_matrix = np.array(([0.0, 1.0], [1.0, 0.0]))
-    x_sqrt_x = np.kron(sqrtm(x_gate_matrix), x_gate_matrix)
+    sqrt_x = np.array([[ 0.5+0.5j,  0.5-0.5j],
+                       [ 0.5-0.5j,  0.5+0.5j]])
+    x_sqrt_x = np.kron(sqrt_x, x_gate_matrix)
     p = Program().defgate("X-SQRT-X", x_sqrt_x)
 
     # Then we can use the new gate
     p.inst(("X-SQRT-X", 0, 1))
 
-    assert p.out() == 'DEFGATE X-SQRT-X:\n    0.0+0.0i, ' \
-                      '0.49999999999999989+0.49999999999999989i, ' \
-                      '0.0+0.0i, 0.49999999999999989-0.49999999999999989i\n    ' \
-                      '0.49999999999999989+0.49999999999999989i, 0.0+0.0i, ' \
-                      '0.49999999999999989-0.49999999999999989i, 0.0+0.0i\n    0.0+0.0i,' \
-                      ' 0.49999999999999989-0.49999999999999989i, 0.0+0.0i, ' \
-                      '0.49999999999999989+0.49999999999999989i\n    ' \
-                      '0.49999999999999989-0.49999999999999989i, ' \
-                      '0.0+0.0i, 0.49999999999999989+0.49999999999999989i, 0.0+0.0i\n\nX-SQRT-X 0 1\n'
+    assert p.out() == 'DEFGATE X-SQRT-X:\n    0.0+0.0i, 0.5+0.5i, 0.0+0.0i, 0.5-0.5i\n    ' \
+                      '0.5+0.5i, 0.0+0.0i, 0.5-0.5i, 0.0+0.0i\n    ' \
+                      '0.0+0.0i, 0.5-0.5i, 0.0+0.0i, 0.5+0.5i\n    ' \
+                      '0.5-0.5i, 0.0+0.0i, 0.5+0.5i, 0.0+0.0i\n\nX-SQRT-X 0 1\n'
 
 
 def test_define_qft():

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     install_requires = [
         'requests >= 2.4.2',
         'numpy >= 1.10',
-        'scipy >= 0.18.0'
     ],
     keywords='quantum quil programming hybrid'
 )


### PR DESCRIPTION
Removes scipy dep in the test for defgate.  Now directly specifies the
sqrt of x gate.

Minor clean up of documentation so x-xqrt-x gate now is the correct
tensor product ordering corresponding to a left most significant bit.