### PR TITLE
Follow up SciPy removal cleanup in documentation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -888,8 +888,7 @@ Next, extend the program to work for any kind of fair die:
 Exercise 2 - Controlled Gates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We can use the full generality of NumPy and SciPy to construct new gate
-matrices.
+We can use the full generality of NumPy to construct new gate matrices.
 
 1. Write a function ``controlled`` which takes a :math:`2\times 2`
    matrix :math:`U` representing a single qubit operator, and makes a

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -846,7 +846,7 @@
    "source": [
     "### Exercise 2 - Controlled Gates\n",
     "\n",
-    "We can use the full generality of NumPy and SciPy to construct new gate matrices.\n",
+    "We can use the full generality of NumPy to construct new gate matrices.\n",
     "\n",
     "1. Write a function `controlled` which takes a $2\\times 2$ matrix $U$ representing a single qubit operator, and makes a $4\\times 4$ matrix which is a controlled variant of $U$, with the first argument being the *control qubit*.\n",
     "\n",


### PR DESCRIPTION
Clean up two stray references to the former SciPy dependency, which was removed in f40fe11e238ff0f4b8d74d47a7471fdc3aa9da66.