### PR TITLE
Integrate pytest and be explicit about test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ our documentation, so this may need to be installed using `pip install sphinx_rt
 
 ## Development and Testing
 
-We use pytest (version > 3.0) for testing. After installing pytest with `pip`, tests can be run from the top-level directory using:
+We use pytest (version > 3.0) and mock for testing. Tests can be run from the top-level directory using:
 ```
-pytest
+python setup.py test
 ```
 
 ## How to cite pyQuil and Forest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,10 @@ setup(
         'requests >= 2.4.2',
         'numpy >= 1.10',
     ],
+    setup_requires = ['pytest-runner'],
+    tests_require = [
+        'pytest >= 3.0.0',
+        'mock',
+    ],
     keywords='quantum quil programming hybrid'
 )


### PR DESCRIPTION
Changes:
- Integrate pytest with `python setup.py test`, as per [0].
- Document test dependencies (pytest and mock) and automate their setup when `python setup.py test` is run. i.e. if in a virtualenv.

[0] https://docs.pytest.org/en/latest/goodpractices.html