### PR TITLE
introduce a Wavefunction object

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -14,9 +14,9 @@ programs.
     p = pq.Program()
     p.inst(H(0), CNOT(0, 1))
         <pyquil.pyquil.Program object at 0x101ebfb50>
-    qvm.wavefunction(p)
-        (array([ 0.70710678+0.j,  0.00000000+0.j,  0.00000000+0.j,  0.70710678+0.j]),
-            [])
+    wvf, _ = qvm.wavefunction(p)
+    print wvf
+        (0.7071067812+0j)|00> + (0.7071067812+0j)|11>
 
 It comes with a few parts:
 
@@ -278,11 +278,42 @@ a program directly, even without measurements:
 
 .. parsed-literal::
 
-    (array([ 0.70710678+0.j,  0.70710678+0.j]), [])
+    (<pyquil.wavefunction.Wavefunction at 0x1088a2c10>, [])
 
 
-The second element in the resulting tuple is an optional amount of classical memory to check along
-with the wavefunction:
+The first element in the returned tuple is a Wavefunction object that stores the amplitudes of the
+quantum state at the conclusion of the program. We can print this object
+
+.. code:: python
+
+    coin_flip = pq.Program().inst(H(0))
+    wvf, _ = qvm.wavefunction(coin_flip)
+    print wvf
+
+.. parsed-literal::
+
+  (0.7071067812+0j)|00> + (0.7071067812+0j)|11>
+
+To see the amplitudes listed as a sum of computational basis states. We can index into those
+amplitudes directly or look at a dictionary of associated outcome probabilities.
+
+.. code:: python
+
+  assert wvf[0] == 1 / np.sqrt(2)
+  # The amplitudes are stored as a numpy array on the Wavefunction object
+  print wvf.amplitudes
+  prob_dict = wvf.get_outcome_probs() # extracts the probabilities of outcomes as a dict
+  print prob_dict
+  prob_dict.keys() # these stores the bitstring outcomes
+  assert len(wvf) == 2 # gives the number of qubits
+
+.. parsed-literal::
+
+  [ 0.70710678+0.j  0.00000000+0.j  0.00000000+0.j  0.70710678+0.j]
+  {'11': 0.49999999999999989, '10': 0.0, '00': 0.49999999999999989, '01': 0.0}
+
+The second element returned from a wavefunction call is an optional amount of classical memory to
+check:
 
 .. code:: python
 
@@ -453,14 +484,14 @@ matrix representation of the gate. For example, below we define a
 
 .. code:: python
 
-    qvm.wavefunction(p)
+    print qvm.wavefunction(p)[0]
 
 
 
 
 .. parsed-literal::
 
-    (array([ 0.5+0.5j,  0.5-0.5j]), [])
+    (0.5+0.5j)|0> + (0.5-0.5j)|1>
 
 
 
@@ -488,7 +519,7 @@ gate.
 
 .. parsed-literal::
 
-    array([ 0.0+0.j ,  0.5+0.5j,  0.0+0.j ,  0.5-0.5j])
+    (0.5+0.5j)|01> + (0.5-0.5j)|11>
 
 
 Advanced Usage
@@ -572,7 +603,7 @@ would return a two-element vector.
 
 .. parsed-literal::
 
-    array([ 0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j])
+    (1+0j)|001>
 
 
 
@@ -583,7 +614,7 @@ after state preparation to get our final result.
 .. code:: python
 
     wavf, _ = qvm.wavefunction(state_prep + qft3(0, 1, 2))
-    print wavf
+    print wavf.amplitudes
 
 
 

--- a/docs/source/intro_to_qc.rst
+++ b/docs/source/intro_to_qc.rst
@@ -217,6 +217,7 @@ Each of the code snippets below will be immediately followed by its output.
     # This call will return the state of our qubits after we run program p.
     # This api call returns a tuple, but we'll ignore the second value for now.
     wavefunc, _ = quantum_simulator.wavefunction(p)
+    # wavefunc is a Wavefunction object that stores a quantum state as a list of amplitudes
     alpha, beta = wavefunc
     print "Our qubit is in the state alpha={} and beta={}".format(alpha, beta)
     print "The probability of measuring the qubit in outcome 0 is {}".format(abs(alpha)**2)

--- a/pyquil/tests/test_forest.py
+++ b/pyquil/tests/test_forest.py
@@ -15,13 +15,15 @@
 #    limitations under the License.
 ##############################################################################
 
-import pyquil.forest as qvm
-import pyquil.quil as pq
-from pyquil.gates import *
+
 import pytest
 import json
 from mock import Mock
 import numpy as np
+
+import pyquil.forest as qvm
+import pyquil.quil as pq
+from pyquil.gates import *
 
 
 @pytest.fixture
@@ -133,5 +135,5 @@ def test_wavefunction(cxn_wf, prog_wf):
     wf_expected = np.array(
         [0.00000000 + 0.j, 0.00000000 + 0.j, 0.70710678 + 0.j, -0.70710678 + 0.j])
     mem_expected = [1, 0]
-    assert np.all(np.isclose(wf, wf_expected))
+    assert np.all(np.isclose(wf.amplitudes, wf_expected))
     assert mem == mem_expected

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -1,0 +1,40 @@
+import pytest
+import numpy as np
+
+from pyquil.wavefunction import get_bitstring_from_index, Wavefunction
+
+
+@pytest.fixture()
+def wvf():
+    return Wavefunction(np.array([1.0, 1.j, 0.000005, 0.02]))
+
+
+def test_get_bitstring_from_index():
+    assert get_bitstring_from_index(0, 2) == '00'
+    assert get_bitstring_from_index(3, 3) == '011'
+
+    with pytest.raises(IndexError):
+        get_bitstring_from_index(10, 2)
+
+
+def test_parsers(wvf):
+    outcome_probs = wvf.get_outcome_probs()
+    assert len(outcome_probs.keys()) == 4
+
+    pp_wvf = wvf.pretty_print()
+    # this should round out one outcome
+    assert pp_wvf == "(1+0j)|00> + 1j|01> + (0.02+0j)|11>"
+    pp_wvf = wvf.pretty_print(1)
+    assert pp_wvf == "(1+0j)|00> + 1j|01>"
+
+    pp_probs = wvf.pretty_print_probabilities()
+    # this should round out two outcomes
+    assert len(pp_probs.keys()) == 2
+    pp_probs = wvf.pretty_print_probabilities(5)
+    assert len(pp_probs.keys()) == 3
+
+
+def test_ground_state():
+    ground = Wavefunction.ground(2)
+    assert len(ground) == 2
+    assert ground[0] == 1.0

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -1,0 +1,113 @@
+"""
+Module containing the Wavefunction object and methods for working with wavefunctions.
+"""
+import numpy as np
+
+
+class Wavefunction(object):
+
+    def __init__(self, amplitude_vector):
+        """
+        Initializes a wavefunction
+        :param amplitude_vector: A numpy array of complex amplitudes
+        """
+        # TODO assert that the length of the amplitudes vector is a power of 2
+        self.amplitudes = amplitude_vector
+
+    def __len__(self):
+        return len(self.amplitudes).bit_length() - 1
+
+    def __iter__(self):
+        return self.amplitudes.__iter__()
+
+    def __getitem__(self, index):
+        return self.amplitudes[index]
+
+    def __setitem__(self, key, value):
+        self.amplitudes[key] = value
+
+    def __str__(self):
+        return self.pretty_print(decimal_digits=10)
+
+    def get_outcome_probs(self):
+        """
+        Parses a wavefunction (array of complex amplitudes) and returns a dictionary of
+        outcomes and associated probabilities.
+
+        :return: A dict with outcomes as keys and probabilities as values.
+        :rtype: dict
+        """
+        outcome_dict = {}
+        qubit_num = len(self)
+        for index, amplitude in enumerate(self):
+            outcome = get_bitstring_from_index(index, qubit_num)
+            outcome_dict[outcome] = abs(amplitude) ** 2
+        return outcome_dict
+
+    def pretty_print_probabilities(self, decimal_digits=2):
+        """
+        Prints outcome probabilities, ignoring all outcomes with approximately zero probabilities
+        (up to a certain number of decimal digits) and rounding the probabilities to decimal_digits.
+
+        :param int decimal_digits: The number of digits to truncate to.
+        :return: A dict with outcomes as keys and probabilities as values.
+        :rtype: dict
+        """
+        outcome_dict = {}
+        qubit_num = len(self)
+        for index, amplitude in enumerate(self):
+            outcome = get_bitstring_from_index(index, qubit_num)
+            prob = round(abs(amplitude) ** 2, decimal_digits)
+            if prob != 0.:
+                outcome_dict[outcome] = prob
+        return outcome_dict
+
+    def pretty_print(self, decimal_digits=2):
+        """
+        Returns a string repr of the wavefunction, ignoring all outcomes with approximately zero
+        amplitude (up to a certain number of decimal digits) and rounding the amplitudes to
+        decimal_digits.
+
+        :param int decimal_digits: The number of digits to truncate to.
+        :return: A dict with outcomes as keys and complex amplitudes as values.
+        :rtype: str
+        """
+        outcome_dict = {}
+        qubit_num = len(self)
+        pp_string = ""
+        for index, amplitude in enumerate(self):
+            outcome = get_bitstring_from_index(index, qubit_num)
+            amplitude = round(amplitude.real, decimal_digits) + \
+                        round(amplitude.imag, decimal_digits) * 1.j
+            if amplitude != 0.:
+                outcome_dict[outcome] = amplitude
+                pp_string += str(amplitude) + "|{}> + ".format(outcome)
+        if len(pp_string) >= 3:
+            pp_string = pp_string[:-3]  # remove the dangling + if it is there
+        return pp_string
+
+    @classmethod
+    def ground(cls, qubit_num):
+        """
+        Constructs the groundstate wavefunction for a given number of qubits.
+
+        :param int qubit_num:
+        :return: A Wavefunction in the ground state
+        :rtype: Wavefunction
+        """
+        container = np.zeros(2**qubit_num)
+        container[0] = 1.0
+        return cls(container)
+
+
+def get_bitstring_from_index(index, qubit_num):
+    """
+    Returns the bitstring in lexical order that corresponds to the given index in 0 to 2^(qubit_num)
+    :param int index:
+    :param int qubit_num:
+    :return: the bitstring
+    :rtype: str
+    """
+    if index > (2**qubit_num - 1):
+        raise IndexError, "Index {} too large for {} qubits.".format(index, qubit_num)
+    return bin(index)[2:].rjust(qubit_num, '0')


### PR DESCRIPTION
This PR adds a wavefunction object that makes some useful utility functions for parsing wave-functions to be more human readable. 

```
from pyquil.quil import Program
import pyquil.forest as forest
from pyquil.gates import RX, CNOT
qvm = forest.Connection()

p = Program(RX(1.232, 0), CNOT(0,1), RX(3.02123, 1), RX(0.032, 0), CNOT(0,1))
wvf, _ = qvm.wavefunction(p)
wvf.pretty_print()
```
'(0.05+0.01j)|00> + (-0.01-0.03j)|01> + (-0-0.81j)|10> + (-0.58+0j)|11>'
```
wvf.pretty_print(decimal_digits=4)
```
'(0.0491+0.0092j)|00> + (-0.013-0.0347j)|01> + (-0.0006-0.8146j)|10> + (-0.5767-0.0008j)|11>'
```
from pyquil.forest import pretty_print_probabilities
wvf.pretty_print_probabilities()
```
{'10': 0.66, '11': 0.33}
```
wvf.pretty_print_probabilities(decimal_digits=4)
```
{'00': 0.0025, '01': 0.0014, '10': 0.6636, '11': 0.3325}