### PR TITLE
add method to merge a list of pyquil programs

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -128,3 +128,14 @@ class Program(InstructionGroup):
             s += "\n"
         s += super(Program, self).out()
         return s
+
+
+def merge_programs(prog_list):
+    """
+    Merges a list of pyQuil programs into a single one by appending them in sequence
+
+    :param list prog_list: A list of pyquil programs
+    :return: a single pyQuil program
+    :rtype: Program
+    """
+    return sum(prog_list, Program())

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -16,7 +16,7 @@
 ##############################################################################
 
 import pyquil.forest as qvm_endpoint
-from pyquil.quil import Program
+from pyquil.quil import Program, merge_programs
 from pyquil.quilbase import DirectQubit
 from pyquil.gates import I, X, Y, Z, H, T, S, RX, RY, RZ, CNOT, CCNOT, PHASE, CPHASE00, CPHASE01, \
     CPHASE10, CPHASE, SWAP, CSWAP, ISWAP, PSWAP, MEASURE, HALT, WAIT, NOP, RESET, \
@@ -380,3 +380,9 @@ def test_extract_qubits():
     p.inst(X(new_qubit))
     p.synthesize()
     assert p.extract_qubits() == set([0, 1, 2, 3, 4, 5, 6, new_qubit.index()])
+
+
+def test_prog_merge():
+    prog_0 = Program(X(0))
+    prog_1 = Program(Y(0))
+    assert merge_programs([prog_0, prog_1]).out() == (prog_0 + prog_1).out()


### PR DESCRIPTION
It is useful to be able to take a list of pyquil programs and append them sequentially together into one program.  This can almost be done easily using the built-in `sum` method, except it produces a little bug if you don't remember that sum starts with a 0 that you need to change.

Adding a `merge_program` method so that:
```
merge_program([Program(X(0)), Program(Y(0))])
```
gives
```
X 0
Y 0
```
means that the library comes with a built in method with the expected behavior.