### PR TITLE
Modify run_quil.py to use argparse

### DIFF
--- a/examples/run_quil.py
+++ b/examples/run_quil.py
@@ -1,8 +1,9 @@
 """
-This module run basic Quil text files agains the Forest QVM API. Usage
+This module runs basic Quil text files against the Forest QVM API.
 """
-import sys
 
+from __future__ import print_function
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from pyquil.quil import Program
 import pyquil.forest as forest
 
@@ -12,22 +13,24 @@ help_string = "Script takes two arguments. Quil program filename is required as 
               "argument and number of classical registers to return is the optional second " \
               "argument (defaults to 8)."
 
-if __name__ == '__main__':
-    assert len(sys.argv) == 2 or len(sys.argv) == 3, help_string
-    if sys.argv[1] == '-h' or sys.argv[1] == '--help':
-        print help_string
-        sys.exit()
-    filepath = str(sys.argv[1])
-    if len(sys.argv) == 3:
-        classical_register_num = int(sys.argv[2])
-    else:
-        classical_register_num = 8
 
+def parse():
+    parser = ArgumentParser(__doc__, formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument('filepath', help='Quil program filename')
+    parser.add_argument('--classical-register-num', '-n', metavar='N', default=8, type=int,
+                        help="Number of classical registers to return.")
+    args = parser.parse_args()
+    main(args.filepath, args.classical_register_num)
+
+def main(filepath, classical_register_num):
     with open(filepath) as file:
         quil_prog = file.read()
         p = Program(quil_prog)
 
-    print "Running Quil Program from: ", filepath
-    print "---------------------------"
-    print "Output: "
-    print qvm.run(p, range(classical_register_num))
+    print("Running Quil Program from: ", filepath)
+    print("---------------------------")
+    print("Output: ")
+    print(qvm.run(p, list(range(classical_register_num))))
+
+if __name__ == '__main__':
+    parse()


### PR DESCRIPTION
More robust argument parsing.

Note that this slightly changes the usage of this script. The number of classical registers used to be a positional argument. Since it's optional, the unixy convention is to give it a flag. I chose `-n`. We can change it (back) to a simple positional argument if you'd prefer. 

Also sundry modifications to make it python 3 compatible: print function and explicit listification of `range`