### PR TITLE
Real angles for exponentiating i*Pauliterms

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -406,7 +406,7 @@ def exponential_map(term):
     if not np.isclose(np.imag(term.coefficient), 0.0):
         raise TypeError("PauliTerm coefficient must be real")
 
-    coeff = term.coefficient
+    coeff = term.coefficient.real
 
     def exp_wrap(param):
         prog = Program()


### PR DESCRIPTION
Unitaries are generated by exponentiating antihermetian operators.  We
implicitly multiply a Pauli operators by 'i' to form an antihermetian matrix.
Therefore, we can only accept real coefficients.  We were checking for a
zero imaginary component but not making sure the coeff is
defined by a floating point--vs complex float.