### PR TITLE
Remove numpy, wf check power of 2, real coeffs

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -498,6 +498,7 @@ def exponential_map(term):
         raise TypeError("PauliTerm coefficient must be real")
 
     coeff = term.coefficient.real
+    term.coefficient = term.coefficient.real
 
     def exp_wrap(param):
         prog = Program()

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -1,7 +1,6 @@
 """
 Module containing the Wavefunction object and methods for working with wavefunctions.
 """
-import numpy as np
 
 
 class Wavefunction(object):
@@ -11,7 +10,9 @@ class Wavefunction(object):
         Initializes a wavefunction
         :param amplitude_vector: A numpy array of complex amplitudes
         """
-        # TODO assert that the length of the amplitudes vector is a power of 2
+        if len(amplitude_vector) == 0 or len(amplitude_vector) & (len(amplitude_vector) - 1) != 0:
+            raise TypeError("Amplitude vector must have a length that is a power of two")
+
         self.amplitudes = amplitude_vector
 
     def __len__(self):
@@ -95,7 +96,7 @@ class Wavefunction(object):
         :return: A Wavefunction in the ground state
         :rtype: Wavefunction
         """
-        container = np.zeros(2**qubit_num)
+        container = [0] * (2**qubit_num)
         container[0] = 1.0
         return cls(container)
 


### PR DESCRIPTION
General clean up of some modules.

Paulis exponentiate needs to define
the terms coefficient as real so we don't write r + 01j into the quil
program.

Asserting that the amplitude vector is a power of 2 by bit AND.

Removing the numpy dependency in `wavefunction.py`