### PR TITLE
bugfix to accomodate how python3 no longer returns an int after division

### DIFF
--- a/pyquil/job_results.py
+++ b/pyquil/job_results.py
@@ -100,7 +100,7 @@ def recover_complexes(coef_string, classical_addresses):
     """
     num_octets = len(coef_string)
     num_addresses = len(classical_addresses)
-    num_memory_octets = _round_to_next_multiple(num_addresses, 8) / 8
+    num_memory_octets = int(_round_to_next_multiple(num_addresses, 8) / 8)
     num_wavefunction_octets = num_octets - num_memory_octets
 
     # Parse the classical memory
@@ -112,7 +112,7 @@ def recover_complexes(coef_string, classical_addresses):
     mem = mem[0:num_addresses]
 
     # Parse the wavefunction
-    wf = np.zeros(num_wavefunction_octets / OCTETS_PER_COMPLEX_DOUBLE, dtype=np.cfloat)
+    wf = np.zeros(int(num_wavefunction_octets / OCTETS_PER_COMPLEX_DOUBLE), dtype=np.cfloat)
     for i, p in enumerate(range(num_memory_octets, num_octets, OCTETS_PER_COMPLEX_DOUBLE)):
         re_be = coef_string[p: p + OCTETS_PER_DOUBLE_FLOAT]
         im_be = coef_string[p + OCTETS_PER_DOUBLE_FLOAT: p + OCTETS_PER_COMPLEX_DOUBLE]

--- a/pyquil/job_results.py
+++ b/pyquil/job_results.py
@@ -100,7 +100,7 @@ def recover_complexes(coef_string, classical_addresses):
     """
     num_octets = len(coef_string)
     num_addresses = len(classical_addresses)
-    num_memory_octets = int(_round_to_next_multiple(num_addresses, 8) / 8)
+    num_memory_octets = _round_to_next_multiple(num_addresses, 8) // 8
     num_wavefunction_octets = num_octets - num_memory_octets
 
     # Parse the classical memory
@@ -112,7 +112,7 @@ def recover_complexes(coef_string, classical_addresses):
     mem = mem[0:num_addresses]
 
     # Parse the wavefunction
-    wf = np.zeros(int(num_wavefunction_octets / OCTETS_PER_COMPLEX_DOUBLE), dtype=np.cfloat)
+    wf = np.zeros(num_wavefunction_octets // OCTETS_PER_COMPLEX_DOUBLE, dtype=np.cfloat)
     for i, p in enumerate(range(num_memory_octets, num_octets, OCTETS_PER_COMPLEX_DOUBLE)):
         re_be = coef_string[p: p + OCTETS_PER_DOUBLE_FLOAT]
         im_be = coef_string[p + OCTETS_PER_DOUBLE_FLOAT: p + OCTETS_PER_COMPLEX_DOUBLE]


### PR DESCRIPTION
There was a change from Python3 to Python2 in how typecasting after numeric division works. For example:
- Python2.7
```
>>> type(1 / 2)
<type 'int'>
```
- Python3
```
>>> type(1 / 2)
<class 'float'>
```

The changes included in this PR make typecasting to int explicit where needed in `job_result.py` to be more compatible with Python3.

h/t to Andrew Guo for altering us to this