### PR TITLE
QVM_URL endpoint for QPU use

### DIFF
--- a/docs/source/qpu.rst
+++ b/docs/source/qpu.rst
@@ -9,8 +9,15 @@ them using pyQuil.
 .. note::
 
     In order to run experiments on the QPU you will need a specially upgraded API key.  If you are
-    interested in running these experiments, then email us at support@rigetti.com
+    interested in running these experiments, then email us at support@rigetti.com.
 
+Once your API key has been upgraded, update your environment to use the QPU endpoint:
+
+::
+
+    export QVM_URL=https://job.rigetti.com/beta
+
+.. parsed-literal::
 
 Before running any experiments, we need to take a look at what devices are available on the
 platform.

--- a/docs/source/qpu.rst
+++ b/docs/source/qpu.rst
@@ -8,7 +8,7 @@ them using pyQuil.
 
 .. note::
 
-    In order to run experiments on the QPU you will need a specially upgraded API key.  If you are
+    In order to run experiments on the QPU you will need an upgraded API key.  If you are
     interested in running these experiments, then email us at support@rigetti.com.
 
 Once your API key has been upgraded, update your environment to use the QPU endpoint:


### PR DESCRIPTION
Includes instructions on setting `QVM_URL=https://job.rigetti.com/beta` for QPU use.