### PR TITLE
Make pyquil run on Python 3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,6 +29,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+from __future__ import print_function
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
@@ -47,11 +48,11 @@ def remove_secrets(app, what, name, obj, options, signature, return_annotation):
     if what == "class" and name == "pyquil.api.Connection":
         import pyquil.api as pqf
         print("Replacing endpoint secrets in pyquil.api.Connection() signature")
-        print(signature,)
+        print((signature,))
         signature = signature.replace("'{}'".format(pqf.ENDPOINT), "ENDPOINT")
         signature = signature.replace("'{}'".format(pqf.API_KEY), "API_KEY")
         signature = signature.replace("'{}'".format(pqf.USER_ID), "USER_ID")
-        print("--> ", signature)
+        print(("--> ", signature))
         return signature, return_annotation
 
 

--- a/examples/meyer_penny_game.py
+++ b/examples/meyer_penny_game.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##############################################################################
 # Copyright 2016-2017 Rigetti Computing
 #

--- a/examples/pointer.py
+++ b/examples/pointer.py
@@ -15,11 +15,14 @@
 #    limitations under the License.
 ##############################################################################
 
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import pyquil.quil as pq
 from pyquil.gates import X
 from math import floor
-from six.moves import range
 
 
 def changed_bit_pos(a, b):
@@ -116,5 +119,5 @@ def pointer_gate(num_qubits, U):
 
 
 if __name__ == '__main__':
-    H = np.matrix([[1, 1], [1, -1]])/np.sqrt(2)
+    H = old_div(np.matrix([[1, 1], [1, -1]]),np.sqrt(2))
     print(pointer_gate(11, H))

--- a/examples/post_rabi.py
+++ b/examples/post_rabi.py
@@ -1,4 +1,5 @@
+from __future__ import print_function
 import pyquil.api as forest
 qpu = forest.QPUConnection("Z12-13-C4a2")
 res = qpu.rabi(qubit_id=3, start=0.01, stop=0.33, step=0.03, the_time=160)
-print res.success, res.result
+print(res.success, res.result)

--- a/examples/post_ramsey.py
+++ b/examples/post_ramsey.py
@@ -1,4 +1,5 @@
+from __future__ import print_function
 import pyquil.api as forest
 qpu = forest.QPUConnection("Z12-13-C4a2")
 res = qpu.ramsey(qubit_id=3, start=0.01, stop=10, step=0.2, detuning=0.5)
-print res.success, res.result
+print(res.success, res.result)

--- a/examples/post_t1.py
+++ b/examples/post_t1.py
@@ -1,4 +1,5 @@
+from __future__ import print_function
 import pyquil.api as forest
 qpu = forest.QPUConnection("Z12-13-C4a2")
 res = qpu.t1(qubit_id=3, start=0.01, stop=60.0, num_pts=31)
-print res.success, res.result
+print(res.success, res.result)

--- a/examples/quantum_die.py
+++ b/examples/quantum_die.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from builtins import range
 #!/usr/bin/python
 ##############################################################################
 # Copyright 2016-2017 Rigetti Computing
@@ -17,6 +15,8 @@ from builtins import range
 #    limitations under the License.
 ##############################################################################
 
+from __future__ import print_function
+from builtins import range
 import math
 from functools import reduce
 import pyquil.quil as pq

--- a/examples/quantum_die.py
+++ b/examples/quantum_die.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import range
 #!/usr/bin/python
 ##############################################################################
 # Copyright 2016-2017 Rigetti Computing
@@ -20,7 +22,6 @@ from functools import reduce
 import pyquil.quil as pq
 import pyquil.api as forest
 from pyquil.gates import H
-from six.moves import range
 
 def qubits_needed(n):
     """

--- a/examples/run_quil.py
+++ b/examples/run_quil.py
@@ -3,6 +3,7 @@ This module runs basic Quil text files against the Forest QVM API.
 """
 
 from __future__ import print_function
+from builtins import range
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from pyquil.quil import Program
 import pyquil.api as forest

--- a/examples/teleportation.py
+++ b/examples/teleportation.py
@@ -15,6 +15,7 @@
 #    limitations under the License.
 ##############################################################################
 
+from __future__ import print_function
 from pyquil.quil import Program
 import pyquil.api as forest
 from pyquil.gates import X, Z, H, CNOT

--- a/pyquil/api.py
+++ b/pyquil/api.py
@@ -19,6 +19,9 @@ Module for facilitating connections to the QVM / QPU.
 """
 
 from __future__ import print_function
+from builtins import str
+from builtins import int
+from builtins import object
 from requests.packages.urllib3.util import Retry
 from requests.adapters import HTTPAdapter
 from copy import deepcopy
@@ -28,8 +31,6 @@ import os
 import os.path
 import sys
 from six.moves.configparser import ConfigParser, NoOptionError, NoSectionError
-from six.moves import range
-from six import integer_types
 
 import pyquil.quil as pq
 from pyquil.job_results import JobResult, WavefunctionResult, recover_complexes
@@ -147,7 +148,7 @@ def _validate_run_items(run_items):
     """
     if not isinstance(run_items, list):
         raise TypeError("run_items must be a list")
-    if any([not isinstance(i, integer_types) for i in run_items]):
+    if any([not isinstance(i, int) for i in run_items]):
         raise TypeError("run_items list must contain integer values")
 
 
@@ -225,10 +226,10 @@ class JobConnection(object):
 
         if random_seed is None:
             self.random_seed = None
-        elif isinstance(random_seed, integer_types) and random_seed >= 0:
+        elif isinstance(random_seed, int) and random_seed >= 0:
             self.random_seed = random_seed
         else:
-            raise TypeError("random_seed should be None or a non-negative int or long.")
+            raise TypeError("random_seed should be None or a non-negative int.")
 
         self.machine = 'QVM' # default to a QVM Machine Connection
 
@@ -414,7 +415,7 @@ class JobConnection(object):
         if not isinstance(quil_program, pq.Program):
             raise TypeError("quil_program must be a Quil program object")
         _validate_run_items(classical_addresses)
-        if not isinstance(trials, integer_types):
+        if not isinstance(trials, int):
             raise TypeError("trials must be an integer")
 
         payload = {"type": TYPE_MULTISHOT,
@@ -441,7 +442,7 @@ class JobConnection(object):
         if not isinstance(quil_program, pq.Program):
             raise TypeError("quil_program must be a Quil program object")
         _validate_run_items(qubits)
-        if not isinstance(trials, integer_types):
+        if not isinstance(trials, int):
             raise TypeError("trials must be an integer")
 
         payload = {"type": TYPE_MULTISHOT_MEASURE,

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -19,10 +19,10 @@ A lovely bunch of gates and instructions for programming with.  This module is u
 Pythonic sugar for Quil instructions.
 """
 
+from builtins import int
 from .quilbase import (Measurement, Gate, Addr, Wait, Reset, Halt, Nop, ClassicalTrue,
                        ClassicalFalse, ClassicalNot, ClassicalAnd, ClassicalOr, ClassicalMove,
                        ClassicalExchange, DirectQubit, AbstractQubit, issubinstance)
-from six import integer_types
 
 def unpack_classical_reg(c):
     """
@@ -31,7 +31,7 @@ def unpack_classical_reg(c):
     :param c: A list of length 1 or an int or an Addr.
     :return: The address as an Addr.
     """
-    if not (isinstance(c, integer_types) or isinstance(c,(list, Addr))):
+    if not (isinstance(c, (int, list, Addr))):
         raise TypeError("c should be an int or list or Addr")
     if isinstance(c, list) and (len(c) != 1 or not isinstance(c[0], int)):
         raise ValueError("if c is a list, it should be of 1 int")
@@ -50,7 +50,7 @@ def unpack_qubit(qubit):
     :param qubit: An int or AbstractQubit.
     :return: An AbstractQubit instance
     """
-    if isinstance(qubit, integer_types):
+    if isinstance(qubit, int):
         return DirectQubit(qubit)
     elif not isinstance(qubit, AbstractQubit):
         raise TypeError("qubit should be an int or AbstractQubit instance")

--- a/pyquil/job_results.py
+++ b/pyquil/job_results.py
@@ -1,9 +1,12 @@
+from builtins import str
+from builtins import int
+from builtins import range
+from builtins import object
 import base64
 import json
 import struct
 import time
 
-from six import integer_types
 import numpy as np
 
 from pyquil.wavefunction import Wavefunction
@@ -154,7 +157,7 @@ def _octet_bits(o):
     :return: The bits as a list in LSB-to-MSB order.
     :rtype: list
     """
-    if not isinstance(o, integer_types):
+    if not isinstance(o, int):
         raise TypeError("o should be an int")
     if not (0 <= o <= 255):
         raise ValueError("o should be between 0 and 255 inclusive")

--- a/pyquil/parametric.py
+++ b/pyquil/parametric.py
@@ -17,10 +17,12 @@
 """
 Module for creating and defining parametric programs.
 """
+from builtins import zip
+from builtins import range
+from builtins import object
 
 import inspect
 from copy import copy
-from six.moves import range
 
 from .quilbase import Slot
 from .quil import Program

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -19,6 +19,10 @@ Module for working with Pauli algebras.
 """
 
 from __future__ import division
+from builtins import str
+from builtins import int
+from builtins import range
+from builtins import object
 from itertools import product
 import numpy as np
 import copy
@@ -26,8 +30,6 @@ from .quil import Program
 from .gates import H, RZ, RX, CNOT, X, PHASE
 from . import quilbase as pqb
 from numbers import Number
-from six import integer_types
-from six.moves import range
 
 PAULI_OPS = ["X", "Y", "Z", "I"]
 PAULI_PROD = {'ZZ': 'I', 'YY': 'I', 'XX': 'I', 'II': 'I',
@@ -55,7 +57,7 @@ class PauliTerm(object):
         :param float coefficient: The coefficient multiplying the operator, e.g. 1.5 * Z_1
         """
         assert op in PAULI_OPS
-        assert isinstance(index, integer_types) and index >= 0
+        assert isinstance(index, int) and index >= 0
 
         self._ops = {}
         if op != "I":

--- a/pyquil/plots.py
+++ b/pyquil/plots.py
@@ -1,9 +1,12 @@
+from __future__ import division
+from __future__ import absolute_import
+from past.utils import old_div
 import matplotlib.pyplot as plt
 import numpy as np
 from lmfit import Model
 from lmfit.models import update_param_vals
 
-from job_results import RabiResult, RamseyResult, T1Result
+from .job_results import RabiResult, RamseyResult, T1Result
 
 
 def analog_plot(job_result):
@@ -35,7 +38,7 @@ def analog_plot(job_result):
 # T1 decay
 ##################################################################
 def fn_T1_decay(x, baseline, amplitude, T1):
-    return baseline + amplitude * np.exp(-x / T1)
+    return baseline + amplitude * np.exp(old_div(-x, T1))
 
 MIN_DATA_POINTS = 5
 
@@ -77,7 +80,7 @@ class T1DecayModel(Model):
         """
         par = self.guess(x, y, **kwargs)
         if errs is not None:
-            fit = self.fit(y, x=x, weights=1.0 / errs, params=par)
+            fit = self.fit(y, x=x, weights=old_div(1.0, errs), params=par)
         else:
             fit = self.fit(y, x=x, params=par)
         return fit
@@ -102,7 +105,7 @@ class T1DecayModel(Model):
 def fn_T2_Ramsey(x, baseline, amplitude, T2, detuning, x0=0.0):
     """Ramsey lineshape.
     """
-    return baseline + amplitude * np.exp(-x / T2) * np.cos(2 * np.pi * detuning * (x - x0))
+    return baseline + amplitude * np.exp(old_div(-x, T2)) * np.cos(2 * np.pi * detuning * (x - x0))
 
 
 class T2RamseyModel(Model):
@@ -139,7 +142,7 @@ class T2RamseyModel(Model):
         """
         par = self.guess(x, y, **kwargs)
         if errs is not None:
-            fit = self.fit(y, x=x, weights=1.0 / errs, params=par, fit_kws={"nan_policy": "omit"})
+            fit = self.fit(y, x=x, weights=old_div(1.0, errs), params=par, fit_kws={"nan_policy": "omit"})
         else:
             fit = self.fit(y, x=x, params=par, fit_kws={"nan_policy": "omit"})
         return fit

--- a/pyquil/qpu.py
+++ b/pyquil/qpu.py
@@ -1,3 +1,4 @@
+from builtins import filter
 from copy import deepcopy
 import json
 import requests

--- a/pyquil/quil_atom.py
+++ b/pyquil/quil_atom.py
@@ -17,6 +17,7 @@
 """
 Contains the base class for Atomic Quil elements.
 """
+from builtins import object
 
 class QuilAtom(object):
     """

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -17,6 +17,7 @@
 """
 Contains the core pyQuil objects that correspond to Quil instructions.
 """
+from past.builtins import basestring
 from builtins import map
 from builtins import str
 from builtins import int
@@ -66,7 +67,7 @@ def format_matrix_element(element):
     """
     if isinstance(element, (int, float, complex)):
         return format_parameter(element)
-    elif isinstance(element, str):
+    elif isinstance(element, basestring):
         return element
     else:
         assert False, "Invalid matrix element: %r" % element
@@ -159,7 +160,7 @@ class DefGate(AbstractInstruction):
     """
 
     def __init__(self, name, matrix):
-        assert isinstance(name, str)
+        assert isinstance(name, basestring)
         assert isinstance(matrix, (list, np.ndarray, np.matrix))
         if isinstance(matrix, list):
             rows = len(matrix)
@@ -299,7 +300,7 @@ class InstructionGroup(QuilAction):
                     else:
                         rest = [possible_params] + list(rest)
                     self.actions.append(action_install(Instr(op, params, rest)))
-            elif isinstance(instruction, str):
+            elif isinstance(instruction, basestring):
                 self.actions.append(action_install(RawInstr(instruction)))
             elif issubinstance(instruction, QuilAction):
                 self.actions.append(action_install(instruction))
@@ -554,7 +555,7 @@ class RawInstr(AbstractInstruction):
     """
 
     def __init__(self, instr_str):
-        if not isinstance(instr_str, str):
+        if not isinstance(instr_str, basestring):
             raise TypeError("Raw instructions require a string.")
         if not allow_raw_instructions:
             raise RuntimeError("Raw instructions are not allowed. Consider changing"
@@ -577,7 +578,7 @@ class Instr(AbstractInstruction):
     """
 
     def __init__(self, op, params, args):
-        if not isinstance(op, str):
+        if not isinstance(op, basestring):
             raise TypeError("op must be a string")
         self.operator_name = op
         self.parameters = params

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -17,6 +17,10 @@
 """
 Contains the core pyQuil objects that correspond to Quil instructions.
 """
+from builtins import map
+from builtins import str
+from builtins import int
+from builtins import object
 
 import numpy as np
 from copy import deepcopy
@@ -24,7 +28,6 @@ from .quil_atom import QuilAtom
 from .slot import Slot
 from .resource_manager import (AbstractQubit, DirectQubit, Qubit,
                                ResourceManager, check_live_qubit, merge_resource_managers)
-from six import integer_types
 
 allow_raw_instructions = True
 """
@@ -59,9 +62,9 @@ def format_matrix_element(element):
     """
     Formats a parameterized matrix element.
 
-    :param element: {int, float, complex, str} The parameterized element to format.
+    :param element: {int, long, float, complex, str} The parameterized element to format.
     """
-    if isinstance(element, integer_types) or isinstance(element, (float, complex)):
+    if isinstance(element, (int, float, complex)):
         return format_parameter(element)
     elif isinstance(element, str):
         return element
@@ -75,7 +78,7 @@ def format_parameter(element):
 
     :param element: {int, float, long, complex, Slot} Formats a parameter for Quil output.
     """
-    if isinstance(element, integer_types) or isinstance(element, float):
+    if isinstance(element, (int, float)):
         return repr(element)
     elif isinstance(element, complex):
         r = element.real
@@ -97,7 +100,7 @@ class Addr(QuilAtom):
     """
 
     def __init__(self, value):
-        if not isinstance(value, integer_types) or value < 0:
+        if not isinstance(value, int) or value < 0:
             raise TypeError("Addr value must be a non-negative int")
         self.address = value
 

--- a/pyquil/resource_manager.py
+++ b/pyquil/resource_manager.py
@@ -18,11 +18,13 @@
 Contains objects and functions to manage allocation and de-allocation of quantum and classical
 resources in pyQuil.
 """
+from builtins import str
+from builtins import int
+from builtins import object
 
 from itertools import count
 from .quil_atom import QuilAtom
 from copy import copy
-from six import integer_types
 
 class AbstractQubit(QuilAtom):
     """
@@ -39,7 +41,7 @@ class DirectQubit(AbstractQubit):
     """
 
     def __init__(self, index):
-        if not isinstance(index, integer_types) or index < 0:
+        if not isinstance(index, int) or index < 0:
             raise TypeError("index should be a non-negative int")
         self._index = index
 

--- a/pyquil/slot.py
+++ b/pyquil/slot.py
@@ -17,6 +17,10 @@
 """
 Contains Slot pyQuil placeholders for constructing Quil template programs.
 """
+from __future__ import division
+from builtins import str
+from builtins import object
+from past.utils import old_div
 
 class Slot(object):
     """
@@ -65,12 +69,12 @@ class Slot(object):
         return Slot(self, lambda: val * self.value())
 
     def __div__(self, val):
-        return Slot(self, lambda: self.value() / val)
+        return Slot(self, lambda: old_div(self.value(), val))
 
     __truediv__ = __div__
 
     def __rdiv__(self, val):
-        return Slot(self, lambda: val / self.value())
+        return Slot(self, lambda: old_div(val, self.value()))
 
     __rtruediv__ = __rdiv__
 

--- a/pyquil/tests/test_forest.py
+++ b/pyquil/tests/test_forest.py
@@ -1,4 +1,3 @@
-from builtins import object
 #!/usr/bin/python
 ##############################################################################
 # Copyright 2016-2017 Rigetti Computing
@@ -16,7 +15,7 @@ from builtins import object
 #    limitations under the License.
 ##############################################################################
 
-
+from builtins import object
 import pytest
 import json
 from mock import Mock

--- a/pyquil/tests/test_forest.py
+++ b/pyquil/tests/test_forest.py
@@ -1,3 +1,4 @@
+from builtins import object
 #!/usr/bin/python
 ##############################################################################
 # Copyright 2016-2017 Rigetti Computing

--- a/pyquil/tests/test_job_results.py
+++ b/pyquil/tests/test_job_results.py
@@ -1,3 +1,4 @@
+from builtins import range
 from pyquil.job_results import _round_to_next_multiple, _octet_bits
 
 

--- a/pyquil/tests/test_parametric.py
+++ b/pyquil/tests/test_parametric.py
@@ -15,6 +15,8 @@
 #    limitations under the License.
 ##############################################################################
 
+from __future__ import division
+from past.utils import old_div
 from pyquil.quil import Program
 from pyquil.gates import RX, RY, Z
 from pyquil.parametric import ParametricProgram, parametric
@@ -49,13 +51,13 @@ def test_slot_algebra():
     assert expression.value() == 4.0
 
     x._value = 4.0
-    expression = x/y
+    expression = old_div(x,y)
     assert expression.value() == 2.0
-    expression = x/2.0
+    expression = old_div(x,2.0)
     assert expression.value() == 2.0
-    expression = y/x
+    expression = old_div(y,x)
     assert expression.value() == 0.5
-    expression = 2.0/x
+    expression = old_div(2.0,x)
     assert expression.value() == 0.5
 
     expression = x - y

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -15,6 +15,11 @@
 #    limitations under the License.
 ##############################################################################
 
+from __future__ import division
+from builtins import str
+from builtins import zip
+from builtins import range
+from past.utils import old_div
 import pytest
 from pyquil.paulis import (PauliTerm, PauliSum, exponential_map, ID, exponentiate,
                            trotterize, is_zero, check_commutation, commuting_sets, sZ, sX
@@ -23,7 +28,6 @@ from pyquil.quil import Program
 from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
 import math
 from itertools import product
-from six.moves import range
 
 
 def isclose(a, b, rel_tol=1e-10, abs_tol=0.0):
@@ -268,25 +272,25 @@ def test_exponentiate():
     generator = PauliTerm("Z", 1, 1.0) * PauliTerm("Y", 0, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([RX(math.pi / 2.0)(0), CNOT(0, 1), RZ(2.0)(1),
-                                  CNOT(0, 1), RX(-math.pi / 2)(0)])
+    result_prog = Program().inst([RX(old_div(math.pi, 2.0))(0), CNOT(0, 1), RZ(2.0)(1),
+                                  CNOT(0, 1), RX(old_div(-math.pi, 2))(0)])
     compare_progs(prog, result_prog)
 
     # testing change of basis position 1
     generator = PauliTerm("Y", 1, 1.0) * PauliTerm("Z", 0, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([RX(math.pi / 2.0)(1), CNOT(0, 1), RZ(2.0)(1),
-                                  CNOT(0, 1), RX(-math.pi / 2.0)(1)])
+    result_prog = Program().inst([RX(old_div(math.pi, 2.0))(1), CNOT(0, 1), RZ(2.0)(1),
+                                  CNOT(0, 1), RX(old_div(-math.pi, 2.0))(1)])
     compare_progs(prog, result_prog)
 
     # testing circuit for 3-terms with change of basis
     generator = PauliTerm("X", 2, 1.0) * PauliTerm("Y", 1, 1.0) * PauliTerm("Z", 0, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([RX(math.pi / 2.0)(1), H(2), CNOT(0, 1),
+    result_prog = Program().inst([RX(old_div(math.pi, 2.0))(1), H(2), CNOT(0, 1),
                                   CNOT(1, 2), RZ(2.0)(2), CNOT(1, 2),
-                                  CNOT(0, 1), RX(-math.pi / 2.0)(1), H(2)])
+                                  CNOT(0, 1), RX(old_div(-math.pi, 2.0))(1), H(2)])
     compare_progs(prog, result_prog)
 
     # testing circuit for 3-terms non-sequential
@@ -295,11 +299,11 @@ def test_exponentiate():
                                                                                              1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([RX(math.pi / 2.0)(0), RX(math.pi / 2.0)(2),
-                                  RX(math.pi / 2.0)(3), CNOT(0, 2),
+    result_prog = Program().inst([RX(old_div(math.pi, 2.0))(0), RX(old_div(math.pi, 2.0))(2),
+                                  RX(old_div(math.pi, 2.0))(3), CNOT(0, 2),
                                   CNOT(2, 3), RZ(2.0)(3), CNOT(2, 3),
-                                  CNOT(0, 2), RX(-math.pi / 2.0)(0),
-                                  RX(-math.pi / 2.0)(2), RX(-math.pi / 2.0)(3)])
+                                  CNOT(0, 2), RX(old_div(-math.pi, 2.0))(0),
+                                  RX(old_div(-math.pi, 2.0))(2), RX(old_div(-math.pi, 2.0))(3)])
     compare_progs(prog, result_prog)
 
 
@@ -371,9 +375,9 @@ def test_trotterize():
 
     # trotter_order 3 steps 1
     prog = trotterize(term_one, term_two, trotter_order=3, trotter_steps=1)
-    result_prog = Program().inst([H(0), RZ(14.0 / 24)(0), H(0), RZ(4.0 / 3.0)(0),
-                                  H(0), RZ(1.5)(0), H(0), RZ(-4.0 / 3.0)(0),
-                                  H(0), RZ(-2.0 / 24)(0), H(0), RZ(2.0)(0)])
+    result_prog = Program().inst([H(0), RZ(old_div(14.0, 24))(0), H(0), RZ(old_div(4.0, 3.0))(0),
+                                  H(0), RZ(1.5)(0), H(0), RZ(old_div(-4.0, 3.0))(0),
+                                  H(0), RZ(old_div(-2.0, 24))(0), H(0), RZ(2.0)(0)])
     compare_progs(prog, result_prog)
 
 
@@ -401,7 +405,7 @@ def test_check_commutation():
     # more rigorous test.  Get all operators in Pauli group
     p_n_group = ("I", "X", "Y", "Z")
     pauli_list = list(product(p_n_group, repeat=3))
-    pauli_ops = [list(zip(x, range(3))) for x in pauli_list]
+    pauli_ops = [list(zip(x, list(range(3)))) for x in pauli_list]
     pauli_ops_pq = []
     for op in pauli_ops:
         reduced = PauliTerm(op[0][0], op[0][1])

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -15,6 +15,9 @@
 #    limitations under the License.
 ##############################################################################
 
+from __future__ import division
+from builtins import str
+from past.utils import old_div
 import pyquil.api as qvm_endpoint
 from pyquil.quil import Program, merge_programs
 from pyquil.quilbase import DirectQubit
@@ -280,10 +283,10 @@ def test_define_qft():
     def qft3(q0, q1, q2):
         p = Program()
         p.inst(H(q2),
-               CPHASE(pi / 2.0)(q1, q2),
+               CPHASE(old_div(pi, 2.0))(q1, q2),
                H(1),
-               CPHASE(pi / 4.0)(q0, q2),
-               CPHASE(pi / 2.0)(q0, q1),
+               CPHASE(old_div(pi, 4.0))(q0, q2),
+               CPHASE(old_div(pi, 2.0))(q0, q1),
                H(q0),
                SWAP(q0, q2))
         return p

--- a/pyquil/tests/test_resource_manager.py
+++ b/pyquil/tests/test_resource_manager.py
@@ -1,3 +1,4 @@
+from builtins import range
 from pyquil.resource_manager import *
 import pyquil.quil as pq
 from pyquil.gates import *

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -19,7 +19,7 @@ def test_get_bitstring_from_index():
 
 def test_parsers(wvf):
     outcome_probs = wvf.get_outcome_probs()
-    assert len(outcome_probs.keys()) == 4
+    assert len(list(outcome_probs.keys())) == 4
 
     pp_wvf = wvf.pretty_print()
     # this should round out one outcome
@@ -29,9 +29,9 @@ def test_parsers(wvf):
 
     pp_probs = wvf.pretty_print_probabilities()
     # this should round out two outcomes
-    assert len(pp_probs.keys()) == 2
+    assert len(list(pp_probs.keys())) == 2
     pp_probs = wvf.pretty_print_probabilities(5)
-    assert len(pp_probs.keys()) == 3
+    assert len(list(pp_probs.keys())) == 3
 
 
 def test_ground_state():

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -1,6 +1,8 @@
 """
 Module containing the Wavefunction object and methods for working with wavefunctions.
 """
+from builtins import str
+from builtins import object
 
 
 class Wavefunction(object):

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=["pyquil"],
     license="LICENSE",
     install_requires=[
+        'future == 0.16.0',
         'requests >= 2.4.2',
         'numpy >= 1.10',
         'matplotlib >= 1.5',


### PR DESCRIPTION
The '/' operator is replaced with `old_div`, so you can see precisely where they are. `futurize` is used to make the code Py2/3 compatible[1].

[1] http://python-future.org/automatic_conversion.html