### PR TITLE
[WIP] Introduce Mypy type annotation to paulis.py

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -20,6 +20,11 @@ Module for working with Pauli algebras.
 
 from __future__ import division
 from itertools import product
+
+from typing import (
+    Dict, Iterator, List, Tuple, Union
+)
+
 import numpy as np
 import copy
 from .quil import Program
@@ -47,6 +52,7 @@ class PauliTerm(object):
     """
 
     def __init__(self, op, index, coefficient=1.0):
+        # type: (str, int, float) -> None
         """ Create a new Pauli Term with a Pauli operator at a particular index and a leading
         coefficient.
 
@@ -57,14 +63,15 @@ class PauliTerm(object):
         assert op in PAULI_OPS
         assert isinstance(index, integer_types) and index >= 0
 
-        self._ops = {}
+        self._ops = {}  # type: Dict[int,str]
         if op != "I":
             self._ops[index] = op
 
         self.coefficient = coefficient
-        self._id = None
+        self._id = ""
 
     def id(self):
+        # type: () -> str
         """
         Returns the unique identifier string for the PauliTerm.  Used in the
         simplify method of PauliSum.
@@ -72,7 +79,7 @@ class PauliTerm(object):
         :return: The unique identifier for this term.
         :rtype: string
         """
-        if self._id is not None:
+        if self._id is not "":
             return self._id
         else:
             s = ""
@@ -82,9 +89,11 @@ class PauliTerm(object):
             return s
 
     def __eq__(self, other):
+        # type: (PauliTerm) -> bool
         return self.id() == other.id()
 
     def __len__(self):
+        # type: () -> int
         """
         The length of the PauliTerm is the number of Pauli operators in the term. A term that
         consists of only a scalar has a length of zero.
@@ -92,19 +101,23 @@ class PauliTerm(object):
         return len(self._ops)
 
     def get_qubits(self):
+        # type: () -> List[int]
         """Gets all the qubits that this PauliTerm operates on.
         """
         # sort the keys to get a deterministic iteration order over qubits
         return sorted(self._ops.keys())
 
     def __getitem__(self, i):
+        # type: (int) -> str
         return self._ops.get(i, "I")
 
     def __iter__(self):
+        # type: () -> Iterator[Tuple[int, str]]
         for i in self.get_qubits():
             yield i, self[i]
 
     def _multiply_factor(self, factor, index):
+        # type: (str, int) -> PauliTerm
         new_term = PauliTerm("I", 0)
         new_coeff = self.coefficient
         new_ops = self._ops.copy()
@@ -123,6 +136,7 @@ class PauliTerm(object):
         return new_term
 
     def __mul__(self, term):
+        # type: (Union[PauliTerm, PauliSum, Number]) -> PauliTerm
         """Multiplies this Pauli Term with another PauliTerm, PauliSum, or number according to the
         Pauli algebra rules.
 
@@ -144,6 +158,7 @@ class PauliTerm(object):
             return term_with_coeff(new_term, new_term.coefficient * new_coeff)
 
     def __rmul__(self, other):
+        # type: (Number) -> PauliTerm
         """Multiplies this PauliTerm with another object, probably a number.
 
         :param other: A number or PauliTerm to multiply by
@@ -154,6 +169,7 @@ class PauliTerm(object):
         return self * other
 
     def __add__(self, other):
+        # type: (Union[PauliTerm, Number]) -> PauliSum
         """Adds this PauliTerm with another one.
 
         :param other: A PauliTerm object or a Number
@@ -161,7 +177,7 @@ class PauliTerm(object):
         :rtype: PauliSum
         """
         if isinstance(other, Number):
-            return self + PauliTerm("I", 0, other)
+            return self + PauliTerm("I", 0, float(other))
         elif isinstance(other, PauliSum):
             return other + self
         else:
@@ -169,16 +185,18 @@ class PauliTerm(object):
             return new_sum.simplify()
 
     def __radd__(self, other):
+        # type: (Number) -> PauliSum
         """Adds this PauliTerm with a Number.
 
         :param other: A PauliTerm object or a Number
         :returns: A new PauliTerm
-        :rtype: PauliTerm
+        :rtype: PauliSum
         """
         assert isinstance(other, Number)
         return self + other
 
     def __sub__(self, other):
+        # type: (PauliTerm) -> PauliSum
         """Subtracts a PauliTerm from this one.
 
         :param other: A PauliTerm object or a Number
@@ -188,6 +206,7 @@ class PauliTerm(object):
         return self + -1. * other
 
     def __rsub__(self, other):
+        # type: (Union[Number, PauliTerm]) -> PauliSum
         """Subtracts this PauliTerm from a Number or PauliTerm.
 
         :param other: A PauliTerm object or a Number
@@ -197,6 +216,7 @@ class PauliTerm(object):
         return other + -1. * self
 
     def __str__(self):
+        # type: () -> str
         term_strs = []
         for index in sorted(self._ops.keys()):
             term_strs.append("%s%s" % (self[index], index))
@@ -247,6 +267,7 @@ A function that returns the sigma_Z operator on a particular qubit.
 
 
 def term_with_coeff(term, coeff):
+    # type: (PauliTerm, float) -> PauliTerm
     """
     Change the coefficient of a PauliTerm.
 
@@ -265,6 +286,7 @@ class PauliSum(object):
     """
 
     def __init__(self, terms):
+        # type: (List[PauliTerm]) -> None
         """
         :param list terms: A list of PauliTerms.
         """
@@ -274,9 +296,11 @@ class PauliSum(object):
             self.terms = terms
 
     def __str__(self):
+        # type: () -> str
         return " + ".join([str(term) for term in self.terms])
 
     def __getitem__(self, item):
+        # type: (int) -> PauliTerm
         """
         :param int item: The index of the term in the sum to return
         :return: The PauliTerm at the index-th position in the PauliSum
@@ -285,9 +309,11 @@ class PauliSum(object):
         return self.terms[item]
 
     def __iter__(self):
+        # type: () -> Iterator[PauliTerm]
         return self.terms.__iter__()
 
     def __mul__(self, other):
+        # type: (Union[PauliSum, PauliTerm, Number]) -> PauliSum
         """
         Multiplies together this PauliSum with PauliSum, PauliTerm or Number objects. The new term
         is then simplified according to the Pauli Algebra rules.
@@ -307,6 +333,7 @@ class PauliSum(object):
         return new_sum.simplify()
 
     def __rmul__(self, other):
+        # type: (Union[PauliSum, PauliTerm, Number]) -> PauliSum
         """
         Multiples together this PauliSum with PauliSum, PauliTerm or Number objects. The new term
         is then simplified according to the Pauli Algebra rules.
@@ -322,6 +349,7 @@ class PauliSum(object):
         return PauliSum(new_terms).simplify()
 
     def __add__(self, other):
+        # type: (Union[PauliSum, PauliTerm, Number]) -> PauliSum
         """
         Adds together this PauliSum with PauliSum, PauliTerm or Number objects. The new term
         is then simplified according to the Pauli Algebra rules.
@@ -340,6 +368,7 @@ class PauliSum(object):
         return new_sum.simplify()
 
     def __radd__(self, other):
+        # type: (Union[PauliSum, PauliTerm, Number]) -> PauliSum
         """
         Adds together this PauliSum with PauliSum, PauliTerm or Number objects. The new term
         is then simplified according to the Pauli Algebra rules.
@@ -352,6 +381,7 @@ class PauliSum(object):
         return self + other
 
     def __sub__(self, other):
+        # type: (Union[PauliSum, PauliTerm, Number]) -> PauliSum
         """
         Finds the difference of this PauliSum with PauliSum, PauliTerm or Number objects. The new
         term is then simplified according to the Pauli Algebra rules.
@@ -363,6 +393,7 @@ class PauliSum(object):
         return self + -1. * other
 
     def __rsub__(self, other):
+        # type: (Union[PauliSum, PauliTerm, Number]) -> PauliSum
         """
         Finds the different of this PauliSum with PauliSum, PauliTerm or Number objects. The new
         term is then simplified according to the Pauli Algebra rules.
@@ -374,6 +405,7 @@ class PauliSum(object):
         return other + -1. * self
 
     def get_qubits(self):
+        # TODO
         """
         The support of all the operators in the PauliSum object.
 
@@ -383,6 +415,7 @@ class PauliSum(object):
         return list(set().union(*[term.get_qubits() for term in self.terms]))
 
     def simplify(self):
+        # type: () -> PauliSum
         """
         Simplifies the sum of Pauli operators according to Pauli algebra rules.
         """
@@ -399,7 +432,7 @@ class PauliSum(object):
                         terms.append(term_with_coeff(term_list[0], coeff))
             return PauliSum(terms)
 
-        like_terms = {}
+        like_terms = {}  # type: Dict[str,List[PauliTerm]]
         for term in self.terms:
             id = term.id()
             if id not in like_terms:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest >= 3.0.0
 mock
 pytest-cov
 codeclimate-test-reporter
+typing==3.6.1

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     tests_require=[
         'pytest >= 3.0.0',
         'mock',
+        'typing == 3.6.1'
     ],
     test_suite='pyquil.tests',
     keywords='quantum quil programming hybrid'


### PR DESCRIPTION
This ensures the parameters type and return type of each function are consistent.

There are several error messages left to be fixed, the majority require more code-selection handler
```
$ mypy pyquil/paulis.py
pyquil/paulis.py:28: error: No library stub file for module 'numpy'
pyquil/paulis.py:28: note: (Stub files are from https://github.com/python/typeshed)
pyquil/paulis.py:91: error: Argument 1 of "__eq__" incompatible with supertype "object"
pyquil/paulis.py:131: error: Unsupported operand types for * ("float" and "complex")
pyquil/paulis.py:148: error: Unsupported operand types for * ("float" and "Number")
pyquil/paulis.py:150: error: Incompatible return value type (got "PauliSum", expected "PauliTerm")
pyquil/paulis.py:155: error: Iterable expected
pyquil/paulis.py:180: error: Argument 1 to "float" has incompatible type "Number"; expected "Union[SupportsFloat, str, bytes]"
pyquil/paulis.py:206: error: Unsupported operand types for * ("float" and "PauliTerm")
pyquil/paulis.py:216: error: Unsupported operand types for + ("Union[Number, PauliTerm]" and "PauliTerm")
pyquil/paulis.py:216: error: Unsupported operand types for * ("float" and "PauliTerm")
pyquil/paulis.py:294: error: Unsupported operand types for * ("float" and "PauliTerm")
pyquil/paulis.py:348: error: Unsupported operand types for * ("float" and "Number")
pyquil/paulis.py:393: error: Incompatible return value type (got "float", expected "PauliSum")
pyquil/paulis.py:393: error: Unsupported operand types for + ("PauliSum" and "float")
pyquil/paulis.py:393: error: Unsupported operand types for * ("float" and "Union[PauliSum, PauliTerm, Number]")
pyquil/paulis.py:405: error: Unsupported operand types for * ("float" and "PauliSum")
```

In particular, the error
`pyquil/paulis.py:150: error: Incompatible return value type (got "PauliSum", expected "PauliTerm")` makes me think that almost all the operators do return `PauliSum` instead of `PauliTerm`. Would it be possible to write them so that the operations are closed under the set of `PauliTerm`?