### PR TITLE
Fix bug with DefGate#getConstructor()

### DIFF
--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -21,7 +21,7 @@ Pythonic sugar for Quil instructions.
 
 from .quilbase import (Measurement, Gate, Addr, Wait, Reset, Halt, Nop, ClassicalTrue,
                        ClassicalFalse, ClassicalNot, ClassicalAnd, ClassicalOr, ClassicalMove,
-                       ClassicalExchange, DirectQubit, AbstractQubit, issubinstance)
+                       ClassicalExchange, DirectQubit, AbstractQubit, issubinstance, unpack_qubit)
 from six import integer_types
 
 def unpack_classical_reg(c):
@@ -41,21 +41,6 @@ def unpack_classical_reg(c):
         return Addr(c[0])
     else:
         return Addr(c)
-
-
-def unpack_qubit(qubit):
-    """
-    Get a qubit from an object.
-
-    :param qubit: An int or AbstractQubit.
-    :return: An AbstractQubit instance
-    """
-    if isinstance(qubit, integer_types):
-        return DirectQubit(qubit)
-    elif not isinstance(qubit, AbstractQubit):
-        raise TypeError("qubit should be an int or AbstractQubit instance")
-    else:
-        return qubit
 
 
 def _make_gate(name, num_qubits, num_params=0):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -89,6 +89,21 @@ def format_parameter(element):
     assert False, "Invalid parameter: %r" % element
 
 
+def unpack_qubit(qubit):
+    """
+    Get a qubit from an object.
+
+    :param qubit: An int or AbstractQubit.
+    :return: An AbstractQubit instance
+    """
+    if isinstance(qubit, integer_types):
+        return DirectQubit(qubit)
+    elif isinstance(qubit, AbstractQubit):
+        return qubit
+    else:
+        raise TypeError("qubit should be an int or AbstractQubit instance")
+
+
 class Addr(QuilAtom):
     """
     Representation of a classical bit address.
@@ -198,7 +213,7 @@ class DefGate(AbstractInstruction):
         :returns: A function that constructs this gate on variable qubit indices. E.g.
                   `mygate.get_constructor()(1) applies the gate to qubit 1.`
         """
-        return lambda *qubits: Gate(name=self.name, params=[], qubits=qubits)
+        return lambda *qubits: Gate(name=self.name, params=[], qubits=list(map(unpack_qubit, qubits)))
 
     def num_args(self):
         """

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -45,6 +45,8 @@ def test_defgate():
     test = dg.get_constructor()
     tg = test(DirectQubit(1), DirectQubit(2))
     assert tg.out() == "TEST 1 2"
+    tg = test(1, 2)
+    assert tg.out() == "TEST 1 2"
 
 
 def test_defgate_non_square_should_throw_error():


### PR DESCRIPTION
The docs suggest you should be able to do something like:
```python
mygate.get_constructor()(1)
```

This allows that by converting the int to a DirectQubit.