### PR TITLE
Refactor config and QPUConnection, better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,26 @@ programs (e.g., to get wavefunctions, get multishot experiment data), you will n
 for [Rigetti Forest](http://forest.rigetti.com). This will allow you to run your programs on the
 Rigetti Quantum Virtual Machine (QVM) or on a real quantum processor (QPU).
 
-Once you have your key, you need to set up configuration in the file `.pyquil_config` which
-pyQuil will attempt to find in your home directory by default. (You can change this location by setting the
-environment variable `PYQUIL_CONFIG` to the path of the file.) Loading the `pyquil.api` module
-will print a warning if this is not found. The configuration file is in INI format and should
-contain all the information required to connect to Forest:
-
-```ini
-[Rigetti Forest]
-url: <URL to Rigetti Forest or QVM endpoint>
-key: <Rigetti Forest API key>
-user_id: <Rigetti Forest User ID>
-```
-
-If `url` is not specified, it will default to `https://api.rigetti.com/qvm`.
-
-Alternatively, you may create the `.pyquil_config` automatically by running the following command,
-which will prompt you for the required information (URL, key, and user id). The script will then create
-a file in the proper location (the user's root directory):
-
+Once you have your key, run the following command to automatically set up your config:
 ```
 pyquil-config-setup
 ```
+
+You can also create the configuration file manually if you'd like and place it at `~/.pyquil_config`.
+The configuration file is in INI format and should contain all the information required to connect to Forest:
+
+```
+[Rigetti Forest]
+url: <URL to Rigetti Forest or QVM endpoint>
+key: <Rigetti Forest API key>
+user_id: <Rigetti User ID>
+```
+
+If `url` is not specified, it will default to `https://api.rigetti.com/qvm`.
+You can change the location of this file by setting the `PYQUIL_CONFIG` environment variable.
+
+If you encounter errors or warnings trying to connect to Forest then see the full
+[Getting Started Guide](https://go.rigetti.com/getting-started)
 
 ## Examples using the Rigetti QVM
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -85,43 +85,51 @@ pyQuil can be used to build and manipulate Quil programs without restriction. Ho
 programs (e.g., to get wavefunctions, get multishot experiment data), you will need an API key
 for Rigetti Forest. This will allow you to run your programs on the Rigetti QVM or QPU.
 
-Once you have your key, you need to create a configuration file called ``.pyquil_config``
-which pyQuil will attempt to find in your home directory by default. You can change this location by setting the
-environment variable ``PYQUIL_CONFIG`` to the path of the file.
+`Sign up here <http://forest.rigetti.com>`_ to get a Forest API key, it's free and only takes a few seconds.
 
-.. note::
-  When setting the environment variable make sure to use the full path or include the HOME variable.
-  E.g. ``export PYQUIL_CONFIG=$HOME/<CONFIG_NAME>``
+Run the following command to automatically set up the config. This will prompt you for the required information
+(URL, key, and user id). It will then create a file in the proper location (the user's root directory):
 
-Loading the ``pyquil.forest`` module will print a warning if this is not found. The configuration file is in INI format
-and should contain all the information required to connect to Forest:
+::
+
+    pyquil-config-setup
+
+If the setup completed successfully then you can skip to the next section.
+
+You can also create the configuration file manually if you'd like and place it at ``~/.pyquil_config``.
+The configuration file is in INI format and should contain all the information required to connect to Forest:
 
 ::
 
     [Rigetti Forest]
     url: <URL to Rigetti Forest or QVM endpoint>
     key: <Rigetti Forest API key>
+    user_id: <Rigetti User ID>
 
-Look `here <http://forest.rigetti.com>`_ to learn more about the Forest toolkit.
+Alternatively, you can place the file at your own chosen location and then set the ``PYQUIL_CONFIG`` environment
+variable to the path of the file.
 
-If ``url`` is not set, pyQuil will default to looking for a
-local endpoint at ``127.0.0.1:5000``.
+.. note::
+  You may specify an absolute path or use the ~ to indicate your home directory.
+  On Linux, this points to ``/users/username``.
+  On Mac, this points to ``/Users/Username``.
+  On Windows, this points to ``C:\Users\Username``
 
-You may also create the ``.pyquil_config`` automatically by running the following command,
-which will prompt you for the required information (URL, key, and user id). The script will then create
-a file in the proper location (the user's root directory):
+.. note::
+  Windows users may find it easier to name the file ``pyquil.ini`` and open it using notepad. Then, set the
+  ``PYQUIL_CONFIG`` environment variable by opening up a command prompt and running:
+  ``setenv PYQUIL_CONFIG=C:\Users\Username\pyquil.ini``
 
-::
-
-    pyquil-config-setup
-
-Alternatively, connection information can be provided in environment variables.
+As a last resort, connection information can be provided via environment variables.
 
 ::
 
     export QVM_URL=<URL to Rigetti Forest or QVM endpoint>
     export QVM_API_KEY=<Rigetti Forest API key>
     export QVM_USER_ID=<Rigetti User ID>
+
+If you are still seeing errors or warnings then file a bug using
+`Github Issues <https://github.com/rigetticomputing/pyquil/issues>`_.
 
 Endpoints
 +++++++++
@@ -158,7 +166,7 @@ Basic pyQuil Usage
 
 To ensure that your installation is working correctly, try running the
 following Python commands interactively. First, import the ``quil``
-module (which constructs quantum programs) and the ``forest`` module (which
+module (which constructs quantum programs) and the ``api`` module (which
 allows connections to the Rigetti QVM). We will also import some basic
 gates for pyQuil as well as numpy.
 
@@ -970,7 +978,7 @@ to see if the job result is finished.
 
 .. parsed-literal::
 
-    <class 'pyquil.job_results.JobResult'> {u'status': u'Submitted', u'jobId': u'BLSLJCBGNP'}
+    <class 'pyquil.job_results.JobResult'> {u'status': u'QUEUED', u'jobId': u'BLSLJCBGNP'}
 
 `is_done` updates the ``JobResult`` object once, and returns `True` if the job has completed. 
 Once the job is finished, then the results can be retrieved from the JobResult object:

--- a/pyquil/config.py
+++ b/pyquil/config.py
@@ -1,0 +1,79 @@
+##############################################################################
+# Copyright 2016-2017 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+"""
+Module for reading configuration information about api keys and user ids.
+"""
+
+from __future__ import print_function
+from six.moves.configparser import ConfigParser, NoSectionError, NoOptionError
+from os.path import expanduser
+
+from os import getenv
+
+import sys
+
+
+class PyquilConfig(object):
+    DEFAULT_PYQUIL_CONFIG_PATH = expanduser('~/.pyquil_config')
+    PYQUIL_CONFIG_PATH = getenv('PYQUIL_CONFIG', DEFAULT_PYQUIL_CONFIG_PATH)
+
+    SECTION = "Rigetti Forest"
+    ENDPOINT = "url"
+    API_KEY = "key"
+    USER_ID = "user_id"
+
+    DEFAULT_ENDPOINT = "https://api.rigetti.com/qvm"
+
+    def __init__(self):
+        self.configparser = ConfigParser()
+
+        if len(self.configparser.read(self.PYQUIL_CONFIG_PATH)) == 0:
+            print("! WARNING:\n"
+                  "!   There was an issue finding your pyQuil config file.\n"
+                  "!   Have you run the pyquil-config-setup command yet?\n"
+                  "! See the getting started guide at https://go.rigetti.com/getting-started",
+                  file=sys.stderr)
+
+    @property
+    def endpoint(self):
+        endpoint = self._env_or_config('QVM_URL', self.ENDPOINT)
+        return endpoint if endpoint else self.DEFAULT_ENDPOINT
+
+    @property
+    def api_key(self):
+        return self._env_or_config('QVM_API_KEY', self.API_KEY)
+
+    @property
+    def user_id(self):
+        return self._env_or_config('QVM_USER_ID', self.USER_ID)
+
+    def _env_or_config(self, env, name):
+        """
+        Get the value of the environment variable or config file value.
+        The environment variable takes precedence.
+
+        :param env: The environment variable name.
+        :param name: The config file key.
+        :return: The value or None if not found
+        """
+        env_val = getenv(env)
+        if env_val is not None:
+            return env_val
+
+        try:
+            return self.configparser.get(self.SECTION, name)
+        except (NoSectionError, NoOptionError, KeyError):
+            return None

--- a/pyquil/qpu.py
+++ b/pyquil/qpu.py
@@ -1,8 +1,6 @@
-from copy import deepcopy
-import json
 import requests
 
-from pyquil.api import JobConnection, USER_ID, API_KEY, _validate_run_items
+from pyquil.api import JobConnection, _validate_run_items
 import pyquil.quil as pq
 from pyquil.job_results import RamseyResult, RabiResult, T1Result
 ENDPOINT = "https://job.rigetti.com/beta"
@@ -14,11 +12,11 @@ class NoParametersFoundException(Exception):
 
 class QPUConnection(JobConnection):
 
-    def __init__(self, device_name, *args):
-        super(QPUConnection, self).__init__(*args)
+    def __init__(self, device_name, **kwargs):
+        super(QPUConnection, self).__init__(**kwargs)
         self.device_name = device_name
         self.machine = "QPU"
-        self.session.headers = self.json_headers
+        self.session.headers = self.headers
         self.endpoint = ENDPOINT
 
     def get_qubits(self):
@@ -26,7 +24,7 @@ class QPUConnection(JobConnection):
         :return: A list of active qubit ids on this device.
         :rtype: list
         """
-        config_dict = get_info()
+        config_dict = self.get_info()
         device_config = config_dict[self.device_name]
         return [qq['num'] for qq in device_config['qubits']]
 
@@ -37,7 +35,7 @@ class QPUConnection(JobConnection):
         :param int qubit_id:
         :return: A RabiResult object
         """
-        payload = get_rabi_params(self.device_name, qubit_id)
+        payload = self.get_rabi_params(qubit_id)
         payload.update({
             'type': 'pyquillow',
             'experiment': 'rabi',
@@ -54,7 +52,7 @@ class QPUConnection(JobConnection):
          :param int qubit_id:
          :return: A RamseyResult object
          """
-        payload = get_ramsey_params(self.device_name, qubit_id)
+        payload = self.get_ramsey_params(qubit_id)
         payload.update({
             'type': 'pyquillow',
             'experiment': 'ramsey',
@@ -71,7 +69,7 @@ class QPUConnection(JobConnection):
          :param int qubit_id:
          :return: A T1Result object
          """
-        payload = get_t1_params(self.device_name, qubit_id)
+        payload = self.get_t1_params(qubit_id)
         payload.update({
             'type': 'pyquillow',
             'experiment': 't1',
@@ -108,7 +106,7 @@ class QPUConnection(JobConnection):
                    'qcid': 0,
                    'experiment': 'quil'}
 
-        res = self.post_job(payload, headers=self.json_headers)
+        res = self.post_job(payload, headers=self.headers)
         return self.process_response(res)
 
     def run_and_measure(self, quil_program, qubits, trials=1):
@@ -120,94 +118,85 @@ class QPUConnection(JobConnection):
     def bit_string_probabilities(self, quil_program):
         return NotImplementedError
 
-
-def get_info():
-    """
-    Gets information about what devices are currently available through the Forest API.
-    :return: A JSON dictionary with configuration information.
-    """
-    url = ENDPOINT + "/config"
-    headers = {
-            'Content-Type' : 'application/json; charset=utf-8',
-            'x-api-key' : API_KEY,
-            'x-user-id' : USER_ID,
-    }
-    res = requests.get(url, headers=headers)
-    config_json = res.json()
-    return config_json
-
-
-def get_params(device_name, qcid, func):
-    """
-    Get and parse the configuration information from the Forest API.
-    :param str device_name: The device to get info for
-    :param int qcid: The qubit number to look at
-    :param func: A function to apply to the qubit specific JSON dictionary of config info
-    :return:
-    """
-    config_dict = get_info()
-    try:
-        device_config = [dd for dd in config_dict['devices'] if dd['name'] == device_name][0]
-        device_config = device_config['qubits']
-    except (KeyError, IndexError):
-        raise NoParametersFoundException("Device with name {} not found.".format(device_name))
-    for qc in device_config:
-        if qc['num'] == qcid:
-            return func(qc)
-    raise NoParametersFoundException
-
-
-def get_rabi_params(device_name, qcid):
-    """
-    Gets the current Rabi experiment parameters for a specific qubit on a specific device
-    :param str device_name:
-    :param int qcid:
-    :return: A dictionary with the parameter info
-    :rtype: dict
-    """
-    def rabi_parse(qc):
-        rabi_params = qc['rabi_params']
-        return {
-            'start': rabi_params['start'],
-            'stop': rabi_params['stop'],
-            'step': rabi_params['step'],
-            'time': rabi_params['time'],
+    def get_info(self):
+        """
+        Gets information about what devices are currently available through the Forest API.
+        :return: A JSON dictionary with configuration information.
+        """
+        url = self.endpoint + "/config"
+        headers = {
+                'Content-Type' : 'application/json; charset=utf-8',
+                'x-api-key' : self.api_key,
+                'x-user-id' : self.user_id,
         }
-    return get_params(device_name, qcid, rabi_parse)
+        res = requests.get(url, headers=headers)
+        config_json = res.json()
+        return config_json
 
+    def get_params(self, qcid, func):
+        """
+        Get and parse the configuration information from the Forest API.
+        :param int qcid: The qubit number to look at
+        :param func: A function to apply to the qubit specific JSON dictionary of config info
+        :return:
+        """
+        config_dict = self.get_info()
+        try:
+            device_config = [dd for dd in config_dict['devices'] if dd['name'] == self.device_name][0]
+            device_config = device_config['qubits']
+        except (KeyError, IndexError):
+            raise NoParametersFoundException("Device with name {} not found.".format(self.device_name))
+        for qc in device_config:
+            if qc['num'] == qcid:
+                return func(qc)
+        raise NoParametersFoundException
 
-def get_ramsey_params(device_name, qcid):
-    """
-    Gets the current Ramsey experiment parameters for a specific qubit on a specific device
-    :param str device_name:
-    :param int qcid:
-    :return: A dictionary with the parameter info
-    :rtype: dict
-    """
-    def ramsey_parse(qc):
-        ramsey_params = qc['ramsey_params']
-        return {
-            'start': ramsey_params['start'],
-            'stop': ramsey_params['stop'],
-            'step': ramsey_params['step'],
-            'detuning': ramsey_params['detuning'],
-        }
-    return get_params(device_name, qcid, ramsey_parse)
+    def get_rabi_params(self, qcid):
+        """
+        Gets the current Rabi experiment parameters for a specific qubit on a specific device
+        :param int qcid:
+        :return: A dictionary with the parameter info
+        :rtype: dict
+        """
+        def rabi_parse(qc):
+            rabi_params = qc['rabi_params']
+            return {
+                'start': rabi_params['start'],
+                'stop': rabi_params['stop'],
+                'step': rabi_params['step'],
+                'time': rabi_params['time'],
+            }
+        return self.get_params(qcid, rabi_parse)
 
+    def get_ramsey_params(self, qcid):
+        """
+        Gets the current Ramsey experiment parameters for a specific qubit on a specific device
+        :param int qcid:
+        :return: A dictionary with the parameter info
+        :rtype: dict
+        """
+        def ramsey_parse(qc):
+            ramsey_params = qc['ramsey_params']
+            return {
+                'start': ramsey_params['start'],
+                'stop': ramsey_params['stop'],
+                'step': ramsey_params['step'],
+                'detuning': ramsey_params['detuning'],
+            }
+        return self.get_params(qcid, ramsey_parse)
 
-def get_t1_params(device_name, qcid):
-    """
-    Gets the current T1 experiment parameters for a specific qubit on a specific device
-    :param str device_name:
-    :param int qcid:
-    :return: A dictionary with the parameter info
-    :rtype: dict
-    """
-    def t1_parse(qc):
-        t1_params = qc['t1_params']
-        return {
-            'start': t1_params['start'],
-            'stop': t1_params['stop'],
-            'num_pts': t1_params['num_pts'],
-        }
-    return get_params(device_name, qcid, t1_parse)
+    def get_t1_params(self, qcid):
+        """
+        Gets the current T1 experiment parameters for a specific qubit on a specific device
+        :param int qcid:
+        :return: A dictionary with the parameter info
+        :rtype: dict
+        """
+        def t1_parse(qc):
+            t1_params = qc['t1_params']
+            return {
+                'start': t1_params['start'],
+                'stop': t1_params['stop'],
+                'num_pts': t1_params['num_pts'],
+            }
+        return self.get_params(qcid, t1_parse)

--- a/pyquil/setup/pyquil_config_setup.py
+++ b/pyquil/setup/pyquil_config_setup.py
@@ -14,29 +14,30 @@
 #    limitations under the License.
 ##############################################################################
 
-from os.path import expanduser
-
 import six
+
+from pyquil.config import PyquilConfig
+
 input = six.moves.input
 
 
 def main():
-    print("Welcome to the pyquil config setup!")
+    print("Welcome to PyQuil!")
     print("Enter the required information below for Forest connections.")
+    print("If you haven't signed up yet you will need to do so first at https://forest.rigetti.com")
 
-    endpoint = input("Forest URL (https://api.rigetti.com/qvm): ")
+    endpoint = input("Forest URL (" + PyquilConfig.DEFAULT_ENDPOINT + "): ")
     if len(endpoint) == 0:
-        endpoint = "https://api.rigetti.com/qvm"
+        endpoint = PyquilConfig.DEFAULT_ENDPOINT
     key = input("Forest API Key: ")
     user = input("User ID: ")
 
-    path = expanduser("~/.pyquil_config")
-    with open(path, 'a+') as f:
-        f.seek(0)
-        f.truncate()
-        f.write("[Rigetti Forest]\n")
-        f.write("url: %s\n" % endpoint)
-        f.write("key: %s\n" % key)
-        f.write("user id: %s" % user)
+    path = PyquilConfig.DEFAULT_PYQUIL_CONFIG_PATH
+    with open(path, 'w') as f:
+        f.write("[" + PyquilConfig.SECTION + "]\n")
+        f.write(PyquilConfig.ENDPOINT + ": " + endpoint + "\n")
+        f.write(PyquilConfig.API_KEY + ": " + key + "\n")
+        f.write(PyquilConfig.USER_ID + ": " + user + "\n")
 
-    print("File created at '%s'" % path)
+    print("Pyquil config file created at '%s'" % path)
+    print("If you experience any problems see the guide at https://go.rigetti.com/getting-started")

--- a/pyquil/tests/test_qpu.py
+++ b/pyquil/tests/test_qpu.py
@@ -2,8 +2,7 @@ import mock
 import pytest
 import json
 
-from pyquil.qpu import get_ramsey_params, get_rabi_params, get_t1_params, \
-    NoParametersFoundException, QPUConnection
+from pyquil.qpu import NoParametersFoundException, QPUConnection
 
 @pytest.fixture()
 def sample_config():
@@ -47,7 +46,7 @@ def sample_config():
 
 
 def test_qpu_rabi(sample_config):
-    with mock.patch('pyquil.qpu.get_info') as m_get_info:
+    with mock.patch.object(QPUConnection, 'get_info') as m_get_info:
         m_get_info.return_value = sample_config
         with mock.patch.object(QPUConnection, "post_json") as m_post:
             mocked_response = {'jobId': "ASHJKSDUK", 'result': [[1]]}
@@ -58,14 +57,13 @@ def test_qpu_rabi(sample_config):
             message = {'machine': 'QPU',
                        'program': {'start': 0.01, 'step': 0.2, 'experiment': 'rabi', 'time': 160.0,
                                    'type': 'pyquillow', 'qcid': 2, 'stop': 20,
-                                   'device_id': device_name},
-                       'results': '', 'jobId': ''}
+                                   'device_id': device_name}}
             # userIds are passed in the message, but shouldn't be tested against
             assert message == anon_message(m_post.call_args[0][0])
 
 
 def test_qpu_ramsey(sample_config):
-    with mock.patch('pyquil.qpu.get_info') as m_get_info:
+    with mock.patch.object(QPUConnection, 'get_info') as m_get_info:
         m_get_info.return_value = sample_config
         with mock.patch.object(QPUConnection, "post_json") as m_post:
             mocked_response = {'jobId': "ASHJKSDUK", 'result': [[1]]}
@@ -76,14 +74,13 @@ def test_qpu_ramsey(sample_config):
             message = {'machine': 'QPU',
                        'program': {'start': 0.01, 'step': 0.2, 'experiment': 'ramsey',
                                    'type': 'pyquillow', 'qcid': 3, 'stop': 20, 'detuning': 0.5,
-                                   'device_id': device_name},
-                       'results': '', 'jobId': ''}
+                                   'device_id': device_name}}
             # userIds are passed in the message, but shouldn't be tested against
             assert message == anon_message(m_post.call_args[0][0])
 
 
 def test_qpu_t1(sample_config):
-    with mock.patch('pyquil.qpu.get_info') as m_get_info:
+    with mock.patch.object(QPUConnection, 'get_info') as m_get_info:
         m_get_info.return_value = sample_config
         with mock.patch.object(QPUConnection, "post_json") as m_post:
             mocked_response = {'jobId': "ASHJKSDUK", 'result': [[1]]}
@@ -93,8 +90,7 @@ def test_qpu_t1(sample_config):
             qpu.t1(2)
             message = {'machine': 'QPU',
                        'program': {'start': 0.01, 'experiment': 't1', 'type': 'pyquillow',
-                                   'qcid': 2, 'stop': 20, 'num_pts': 25, 'device_id':device_name},
-                       'results': '', 'jobId': ''}
+                                   'qcid': 2, 'stop': 20, 'num_pts': 25, 'device_id':device_name}}
             # userIds are passed in the message, but shouldn't be tested against
             assert message == anon_message(m_post.call_args[0][0])
 
@@ -105,17 +101,17 @@ def anon_message(message):
 
 
 def test_get_params(sample_config):
-    with mock.patch('pyquil.qpu.get_info') as m_get_info:
+    with mock.patch.object(QPUConnection, 'get_info') as m_get_info:
         m_get_info.return_value = sample_config
-        assert get_rabi_params("Z12-13-C4a2", 2) == {'start': 0.01, 'stop': 20, 'step': 0.2,
+        device_name = "Z12-13-C4a2"
+        qpu = QPUConnection(device_name)
+        assert qpu.get_rabi_params(2) == {'start': 0.01, 'stop': 20, 'step': 0.2,
                                                      'time': 160.}
-        assert get_ramsey_params("Z12-13-C4a2", 2) == {'start': 0.01, 'stop': 20, 'step': 0.2,
+        assert qpu.get_ramsey_params(2) == {'start': 0.01, 'stop': 20, 'step': 0.2,
                                                        'detuning': 0.5}
-        assert get_t1_params("Z12-13-C4a2", 3) == {'start': 0.01, 'stop': 20, 'num_pts': 25}
+        assert qpu.get_t1_params(3) == {'start': 0.01, 'stop': 20, 'num_pts': 25}
 
-        getters = [get_rabi_params, get_ramsey_params, get_t1_params]
+        getters = [qpu.get_rabi_params, qpu.get_ramsey_params, qpu.get_t1_params]
         for getter in getters:
             with pytest.raises(NoParametersFoundException):
-                getter("Z12-13-C4a2", 5)
-            with pytest.raises(NoParametersFoundException):
-                getter("Z12-13-C0a2", 2)
+                getter(5)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     test_suite='pyquil.tests',
     entry_points={
-        'console_scripts': ['pyquil-config-setup=pyquil.setup.config:main']
+        'console_scripts': ['pyquil-config-setup=pyquil.setup.pyquil_config_setup:main']
     },
     keywords='quantum quil programming hybrid'
 )


### PR DESCRIPTION
Fixes issue #128

This does a number of things:
- improves the getting started guide to deal with problems frequently encountered by support
- fixes and improves the pyquil-config-setup script
- points users to use the pyquil-config-setup script instead of doing it themselves
- refactors config file parsing the QPUConnection object to be less global

Here's what a user seems when they try to open up a connection for the first time with no .pyquil_config file:
```
>>> from pyquil.api import SyncConnection
>>> SyncConnection()
! WARNING:
!   There was an issue finding your pyQuil config file.
!   Have you run the pyquil-config-setup command yet?
! See the getting started guide at https://go.rigetti.com/getting-started
```

Here's what they see if they forge on ahead anyway:
```
>>> qvm.run(Program(), [])
! ERROR:
!   There was an issue validating your forest account.
!   Have you run the pyquil-config-setup command yet?
! The server came back with the following information:
================================================================================
{"message":"Forbidden"}
================================================================================
! If you suspect this to be a bug in pyQuil or Rigetti Forest,
! then please describe the problem in a GitHub issue at:
!
!      https://github.com/rigetticomputing/pyquil/issues

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/steven/workspace/pyquil/pyquil/api.py", line 371, in run
    res = self.post_job(payload, headers=self.headers)
  File "/Users/steven/workspace/pyquil/pyquil/api.py", line 435, in post_job
    return self.post_json(program, headers)
  File "/Users/steven/workspace/pyquil/pyquil/api.py", line 207, in post_json
    res.raise_for_status()
  File "/Users/steven/.pyenv/versions/pyquil/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.rigetti.com/qvm
```

Personal todo list so I don't forget:
- [x] fix issue where typos in keys throw 500s instead of 400s
- [x] update welcome email to point to pyquil-config-setup
- [x] add /check endpoint to new job server
- [x] build the docs