### PR TITLE
[WIP] Introduce PEP484 type hints to paulis.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tox==2.9.1
 typing==3.6.2
 urllib3==1.22
 virtualenv==15.1.0
+typing==3.6.2

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     tests_require=[
         'pytest >= 3.0.0',
         'mock',
+        'typing == 3.6.2',
     ],
     test_suite='pyquil.tests',
     entry_points={


### PR DESCRIPTION
Current errors:
- [ ] pyquil/paulis.py:22: error: No library stub file for module 'numpy'
- [ ] pyquil/paulis.py:22: note: (Stub files are from https://github.com/python/typeshed)
- [ ] pyquil/paulis.py:95: error: Argument 1 of "__eq__" incompatible with supertype "object"
- [ ] pyquil/paulis.py:104: error: Argument 1 of "__ne__" incompatible with supertype "object"
- [ ] pyquil/paulis.py:181: error: Argument 2 to "term_with_coeff" has incompatible type "complex"; expected "Number"
- [ ] pyquil/paulis.py:181: error: Unsupported operand types for * ("complex" and "Number")
- [ ] pyquil/paulis.py:183: error: Incompatible return value type (got "PauliSum", expected "PauliTerm")
- [ ] pyquil/paulis.py:188: error: Iterable expected
- [ ] pyquil/paulis.py:191: error: Argument 2 to "term_with_coeff" has incompatible type "complex"; expected "Number"
- [ ] pyquil/paulis.py:219: error: Argument 2 to "term_with_coeff" has incompatible type "int"; expected "Number"
- [ ] pyquil/paulis.py:221: error: Unsupported operand types for * ("int" and "PauliTerm")
- [ ] pyquil/paulis.py:221: error: Incompatible types in assignment (expression has type "PauliTerm", variable has type "int")
- [ ] pyquil/paulis.py:223: error: Unsupported operand types for * ("int" and "PauliTerm")
- [ ] pyquil/paulis.py:223: error: Incompatible types in assignment (expression has type "PauliTerm", variable has type "int")
- [ ] pyquil/paulis.py:224: error: Incompatible return value type (got "int", expected "PauliTerm")
- [ ] pyquil/paulis.py:235: error: Argument 1 to "float" has incompatible type "Number"; expected "Union[SupportsFloat, str, bytes]"
- [ ] pyquil/paulis.py:261: error: Incompatible return value type (got "float", expected "PauliSum")
- [ ] pyquil/paulis.py:261: error: Unsupported operand types for + ("PauliTerm" and "float")
- [ ] pyquil/paulis.py:261: error: Unsupported operand types for * ("float" and "Union[PauliTerm, Number]")
- [ ] pyquil/paulis.py:271: error: Unsupported operand types for + ("Union[PauliTerm, Number]" and "PauliTerm")
- [ ] pyquil/paulis.py:271: error: Unsupported operand types for * ("float" and "PauliTerm")
- [ ] pyquil/paulis.py:383: error: No overload variant of "complex" matches argument types [numbers.Number]
- [ ] pyquil/paulis.py:400: error: Unsupported operand types for * ("float" and "PauliTerm")
- [ ] pyquil/paulis.py:404: error: Argument 1 of "__eq__" incompatible with supertype "object"
- [ ] pyquil/paulis.py:421: error: Argument 1 of "__ne__" incompatible with supertype "object"
- [ ] pyquil/paulis.py:471: error: List item 0 has incompatible type "Union[PauliTerm, Number]"
- [ ] pyquil/paulis.py:489: error: Unsupported operand types for * ("complex" and "Number")
- [ ] pyquil/paulis.py:506: error: Argument 2 to "term_with_coeff" has incompatible type "int"; expected "Number"
- [ ] pyquil/paulis.py:508: error: Unsupported operand types for * ("int" and "PauliTerm")
- [ ] pyquil/paulis.py:508: error: Incompatible types in assignment (expression has type "PauliTerm", variable has type "int")
- [ ] pyquil/paulis.py:512: error: Unsupported operand types for * ("int" and "PauliTerm")
- [ ] pyquil/paulis.py:512: error: Incompatible types in assignment (expression has type "PauliTerm", variable has type "int")
- [ ] pyquil/paulis.py:515: error: Unsupported operand types for * ("int" and "PauliSum")
- [ ] pyquil/paulis.py:515: error: Incompatible types in assignment (expression has type "PauliSum", variable has type "int")
- [ ] pyquil/paulis.py:516: error: Incompatible return value type (got "int", expected "PauliSum")
- [ ] pyquil/paulis.py:560: error: Incompatible return value type (got "float", expected "PauliSum")
- [ ] pyquil/paulis.py:560: error: Unsupported operand types for + ("PauliSum" and "float")
- [ ] pyquil/paulis.py:560: error: Unsupported operand types for * ("float" and "Union[PauliSum, PauliTerm, Number]")
- [ ] pyquil/paulis.py:572: error: Unsupported operand types for * ("float" and "PauliSum")