### PR TITLE
pyquil.quilbase: fix docstring

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -345,6 +345,7 @@ class InstructionGroup(QuilAction):
     def extract_qubits(self):
         """
         Return all qubit addresses involved in the instruction group.
+
         :return: Set of qubits.
         :rtype: set
         """


### PR DESCRIPTION
This docstring was missing a newline after the description, so it wasn't properly rendered in the online documentation.