### PR TITLE
Added helper function to define noisy gates as Kraus maps

### DIFF
--- a/pyquil/kraus.py
+++ b/pyquil/kraus.py
@@ -1,0 +1,58 @@
+##############################################################################
+# Copyright 2016-2017 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+"""
+Module for creating and defining Quil programs.
+"""
+import numpy as np
+
+from pyquil.quilbase import format_parameter, Pragma
+
+
+def _check_kraus_ops(n, kraus_ops):
+    """
+    Verify that the Kraus operators are of the correct shape and satisfy the correct normalization.
+
+    :param int n: Number of qubits
+    :param list|tuple kraus_ops: The Kraus operators as numpy.ndarrays.
+    """
+    for k in kraus_ops:
+        if not np.shape(k) == (2 ** n, 2 ** n):
+            raise ValueError(
+                "Kraus operators for {0} qubits must have shape {1}x{1}: {2}".format(n, 2 ** n, k))
+
+    kdk_sum = sum(np.transpose(k).conjugate().dot(k) for k in kraus_ops)
+    if not np.allclose(kdk_sum, np.eye(2**n), atol=1e-5):
+        raise ValueError(
+            "Kraus operator not correctly normalized: sum_j K_j^*K_j == {}".format(kdk_sum))
+
+
+def _create_kraus_pragmas(name, qubit_indices, kraus_ops):
+    """
+    Generate the pragmas to define a Kraus map for a specific gate on some qubits.
+
+    :param str name: The name of the gate.
+    :param list|tuple qubit_indices: The qubits
+    :param list|tuple kraus_ops: The Kraus operators as matrices.
+    :return: A QUIL string with PRAGMA ADD-KRAUS ... statements.
+    :rtype: str
+    """
+
+    prefix = "PRAGMA ADD-KRAUS {} {}".format(name, " ".join(map(str, qubit_indices)))
+    pragmas = [Pragma("ADD-KRAUS",
+                      qubit_indices,
+                      "({})".format(" ".join(map(format_parameter, np.ravel(k)))))
+               for k in kraus_ops]
+    return pragmas

--- a/pyquil/kraus.py
+++ b/pyquil/kraus.py
@@ -14,7 +14,7 @@
 #    limitations under the License.
 ##############################################################################
 """
-Module for creating and defining Quil programs.
+Module for creating and verifying noisy gate definitions in terms of Kraus maps.
 """
 import numpy as np
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -143,7 +143,7 @@ class Program(InstructionGroup):
         """
         kraus_ops = [np.asarray(k, dtype=np.complex128) for k in kraus_ops]
         _check_kraus_ops(len(qubit_indices), kraus_ops)
-        self.inst(*_create_kraus_pragmas(name, tuple(qubit_indices), kraus_ops))
+        self.inst(_create_kraus_pragmas(name, tuple(qubit_indices), kraus_ops))
         return self
 
     def no_noise(self):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -591,6 +591,44 @@ class RawInstr(AbstractInstruction):
         return self.instr
 
 
+class Pragma(AbstractInstruction):
+    """
+    A PRAGMA instruction.
+
+    This is printed in QUIL as::
+
+        PRAGMA <command> <arg1> <arg2> ... <argn> "<freeform_string>"
+
+    """
+
+    def __init__(self, command, args=(), freeform_string=""):
+        if not isinstance(command, str):
+            raise TypeError("Pragma's require an identifier.")
+        for a in args:
+            if not isinstance(a, (str, int)):
+                raise TypeError("Pragma arguments must be strings or integers: {}".format(a))
+        if not isinstance(freeform_string, str):
+            raise TypeError("The freeform string argument must be a string: {}".format(
+                freeform_string))
+        self.command = command
+        self.args = args
+        self.freeform_string = freeform_string
+
+    def out(self):
+        ret = "PRAGMA {}".format(self.command)
+        if len(self.args):
+            ret += " {}".format(" ".join(str(a) for a in self.args))
+        if len(self.freeform_string):
+            ret += " \"{}\"".format(self.freeform_string)
+        return ret
+
+    def __repr__(self):
+        return '<PRAGMA {}>'.format(self.command)
+
+    def __str__(self):
+        return self.out
+
+
 class Instr(AbstractInstruction):
     """
     Representation of an instruction represented by an operator, parameters, and arguments.

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -616,9 +616,9 @@ class Pragma(AbstractInstruction):
 
     def out(self):
         ret = "PRAGMA {}".format(self.command)
-        if len(self.args):
+        if self.args:
             ret += " {}".format(" ".join(str(a) for a in self.args))
-        if len(self.freeform_string):
+        if self.freeform_string:
             ret += " \"{}\"".format(self.freeform_string)
         return ret
 


### PR DESCRIPTION
This implements the new `PRAGMA ADD-KRAUS <GATENAME> <QUBITS+> "(...)"` statements for noisy qvm simulations.
@stevenheidel maybe take a quick look, but even if it looks good let's discuss before merging.