### PR TITLE
Document behavior of JobConnection.{run_and_measure|expectation} for …

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1002,8 +1002,23 @@ Once the job is finished, then the results can be retrieved from the JobResult o
 
   <type 'list'> [[1]]
 
-This same pattern applies to the ``wavefunction``, ``expectation``, and ``run_and_measure`` calls
-on the JobConnection object.
+
+Optimized Calls
+~~~~~~~~~~~~~~~
+
+This same pattern as above applies to the ``wavefunction``, ``expectation``, and ``run_and_measure``
+calls on the JobConnection object.
+These are very useful if used appropriately: They all function by executing a given program once
+and then either returning the final wavefunction or using it to generate
+expectation values or a specified number bitstring samples.
+
+.. warning::
+
+    This behavior can have unexpected consequences if the program that prepares the final state
+    is non-deterministic, e.g., if it contains measurements and/or noisy gate applications.
+    In this case, the final state after the program execution is itself a random variable
+    and a single call to these functions therefore **cannot** sample the full space of outcomes.
+
 
 Exercises
 ---------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -46,9 +46,10 @@ Before you can start writing quantum programs, you will need Python 2.7
 Python package manager pip.
 
 .. note::
-PyQuil works on both Python 2 and 3. However, Rigetti **strongly** recommends
-using Python 3 if possible. Future feature developments in PyQuil may support
-Python 3 only.
+
+    PyQuil works on both Python 2 and 3. However, Rigetti **strongly** recommends
+    using Python 3 if possible. Future feature developments in PyQuil may support
+    Python 3 only.
 
 
 Installation
@@ -1004,13 +1005,15 @@ Once the job is finished, then the results can be retrieved from the JobResult o
 
 
 Optimized Calls
-~~~~~~~~~~~~~~~
+---------------
 
-This same pattern as above applies to the ``wavefunction``, ``expectation``, and ``run_and_measure``
-calls on the JobConnection object.
-These are very useful if used appropriately: They all function by executing a given program once
-and then either returning the final wavefunction or using it to generate
-expectation values or a specified number bitstring samples.
+This same pattern as above applies to the :meth:`~pyquil.api.JobConnection.wavefunction`,
+:meth:`~pyquil.api.JobConnection.expectation` and
+:meth:`~pyquil.api.JobConnection.run_and_measure`
+calls on any :class:`~pyquil.api.JobConnection` or :class:`~pyquil.api.SyncConnection` object.
+These are very useful if used appropriately: They all execute a given program *once and only once*
+and then either return the final wavefunction or use it to generate expectation values or a
+specified number of random bitstring samples.
 
 .. warning::
 
@@ -1018,6 +1021,10 @@ expectation values or a specified number bitstring samples.
     is non-deterministic, e.g., if it contains measurements and/or noisy gate applications.
     In this case, the final state after the program execution is itself a random variable
     and a single call to these functions therefore **cannot** sample the full space of outcomes.
+    Therefore, if the program is non-deterministic and sampling the full program output distribution
+    is important for the application at hand, we recommend using the basic
+    :meth:`~pyquil.api.JobConnection.run` API function as this re-runs the full program for every
+    requested trial.
 
 
 Exercises

--- a/pyquil/api.py
+++ b/pyquil/api.py
@@ -283,6 +283,12 @@ class JobConnection(object):
         """
         Simulate a Quil program and get the wavefunction back.
 
+        :note: If the execution of ``quil_program`` is **non-deterministic**, i.e., if it includes
+            measurements and/or noisy quantum gates, then the final wavefunction from which the
+            returned bitstrings are sampled itself only represents a stochastically generated sample
+            and the wavefunctions returned by *different* ``wavefunction`` calls *will generally be
+            different*.
+
         :param Program quil_program: A Quil program.
         :param list classical_addresses: An optional list of classical addresses.
         :return: A tuple whose first element is a Wavefunction object,

--- a/pyquil/api.py
+++ b/pyquil/api.py
@@ -311,6 +311,12 @@ class JobConnection(object):
         Calculate the expectation value of operators given a state prepared by
         prep_program.
 
+        :note: If the execution of ``quil_program`` is **non-deterministic**, i.e., if it includes
+            measurements and/or noisy quantum gates, then the final wavefunction from which the
+            expectation values are computed itself only represents a stochastically generated
+            sample. The expectations returned from *different* ``expectation`` calls *will then
+            generally be different*.
+
         :param Program prep_prog: Quil program for state preparation.
         :param list operator_programs: A list of PauliTerms. Default is Identity operator.
         :returns: Expectation value of the operators.
@@ -373,6 +379,12 @@ class JobConnection(object):
     def run_and_measure(self, quil_program, qubits, trials=1):
         """
         Run a Quil program once to determine the final wavefunction, and measure multiple times.
+
+        :note: If the execution of ``quil_program`` is **non-deterministic**, i.e., if it includes
+            measurements and/or noisy quantum gates, then the final wavefunction from which the
+            returned bitstrings are sampled itself only represents a stochastically generated sample
+            and the outcomes sampled from *different* ``run_and_measure`` calls *generally sample
+            different bitstring distributions*.
 
         :param Program quil_program: A Quil program.
         :param list qubits: A list of qubits.


### PR DESCRIPTION
…non-deterministic programs

This follows our recent internal Slack discussion. 
The rendered docs look like this: 
![image](https://user-images.githubusercontent.com/1573961/32509024-055fb8f8-c3a1-11e7-83ec-b60b0cfa0d4a.png)
