### PR TITLE
Ensure that gate name is added to ADD-KRAUS args

### DIFF
--- a/pyquil/kraus.py
+++ b/pyquil/kraus.py
@@ -50,9 +50,8 @@ def _create_kraus_pragmas(name, qubit_indices, kraus_ops):
     :rtype: str
     """
 
-    prefix = "PRAGMA ADD-KRAUS {} {}".format(name, " ".join(map(str, qubit_indices)))
     pragmas = [Pragma("ADD-KRAUS",
-                      qubit_indices,
+                      [name] + list(qubit_indices),
                       "({})".format(" ".join(map(format_parameter, np.ravel(k)))))
                for k in kraus_ops]
     return pragmas

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -520,11 +520,11 @@ def test_kraus():
 
     ret = pq.out()
     assert ret == """X 0
-PRAGMA ADD-KRAUS 0 "(0.0+0.0i 1.0+0.0i 1.0+0.0i 0.0+0.0i)"
-PRAGMA ADD-KRAUS 0 "(0.0+0.0i 0.0+0.0i 0.0+0.0i 0.0+0.0i)"
+PRAGMA ADD-KRAUS X 0 "(0.0+0.0i 1.0+0.0i 1.0+0.0i 0.0+0.0i)"
+PRAGMA ADD-KRAUS X 0 "(0.0+0.0i 0.0+0.0i 0.0+0.0i 0.0+0.0i)"
 X 1
-PRAGMA ADD-KRAUS 1 "(0.0+0.0i 1.0+0.0i 1.0+0.0i 0.0+0.0i)"
-PRAGMA ADD-KRAUS 1 "(0.0+0.0i 0.0+0.0i 0.0+0.0i 0.0+0.0i)"
+PRAGMA ADD-KRAUS X 1 "(0.0+0.0i 1.0+0.0i 1.0+0.0i 0.0+0.0i)"
+PRAGMA ADD-KRAUS X 1 "(0.0+0.0i 0.0+0.0i 0.0+0.0i 0.0+0.0i)"
 """
     # test error due to bad normalization
     with pytest.raises(ValueError):


### PR DESCRIPTION
This fixes #176, a bug in the generation of `ADD-KRAUS` pragmas and also removes some unused code.