### PR TITLE
Add blocking resolution method to JobResult

### DIFF
--- a/pyquil/job_results.py
+++ b/pyquil/job_results.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import struct
 import time
 
@@ -46,6 +45,25 @@ class JobResult(object):
         """
         self.get()
         return 'result' in self.result
+
+    def resolve(self, timeout=30, poll_time=0.1):
+        """
+        Blocking call to resolve the underlying result of the JobResult. Returns when the QPU
+        returns the results.
+
+        :param timeout: (Optional) time in sec until the blocking operation raises a TimeoutError.
+         Defaults to 30 sec
+        :param poll_time: (Optional) poll interval in seconds. Defaults to 0.1 sec.
+        :return: the results of of the computation.
+        """
+        start = time.time()
+        if timeout is None:
+            timeout = np.inf
+        while time.time() - start < timeout:
+            if self.is_done():
+                return self.result['result']
+            time.sleep(poll_time)
+        raise TimeoutError("JobExecution exceeded timeout of {} sec".format(timeout))
 
     def job_id(self):
         """

--- a/pyquil/tests/test_job_results.py
+++ b/pyquil/tests/test_job_results.py
@@ -31,3 +31,14 @@ def test_get_is_called():
     with patch.object(job_result, 'get') as mock:
         job_result.is_done()
     mock.assert_called_with()
+
+
+def test_blocking_call():
+    # check that JobResult.resolve() calls .is_done() on QPU prior to
+    # returning result
+    qpu_connect = QPUConnection('test')
+    job_result = JobResult(qpu_connect, False, result={'result': 0})
+    with patch.object(job_result, 'is_done') as mock:
+        res = job_result.resolve()
+    mock.assert_called_with()
+    assert res == 0


### PR DESCRIPTION
Adds blocking method that resolves the result of a JobResult returned from a QPU call. This fixes #195 