### PR TITLE
removed duplicate paulis documentation link

### DIFF
--- a/docs/source/source_docs.rst
+++ b/docs/source/source_docs.rst
@@ -7,7 +7,6 @@ Here you can find documentation for the different submodules in pyQuil.
 .. toctree::
     api
     gates
-    paulis
     parametric
     paulis
     quil


### PR DESCRIPTION
The generated source code documentation has two links to the paulis module documentation. I removed the first duplicate in order to preserve the alphabetical order of the modules in the table of contents listing.