### PR TITLE
PauliSum helper functions for computing expectation

### DIFF
--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -15,12 +15,10 @@
 ##############################################################################
 
 from six import integer_types
-import numpy as np
 
 from pyquil.api import Job
 from pyquil.quil import Program
 from pyquil.wavefunction import Wavefunction
-from pyquil.paulis import PauliSum, PauliTerm
 from ._base_connection import validate_noise_probabilities, validate_run_items, TYPE_MULTISHOT, \
     TYPE_MULTISHOT_MEASURE, TYPE_WAVEFUNCTION, TYPE_EXPECTATION, get_job_id, get_session, wait_for_job, \
     post_json, get_json
@@ -255,34 +253,15 @@ class QVMConnection(object):
         :returns: Expectation value of the operators.
         :rtype: float
         """
-        coefs = None
-
-        try:
-            is_pauli_terms = all(isinstance(p, PauliTerm) for p in operator_programs)
-        except TypeError:
-            # Not iterable
-            is_pauli_terms = False
-
-        if is_pauli_terms:
-            # Turn to a PauliSum
-            operator_programs = sum(operator_programs)
-
-        if isinstance(operator_programs, PauliSum):
-            operator_programs, coefs = operator_programs.get_programs()
-
         if self.use_queue:
             payload = self._expectation_payload(prep_prog, operator_programs)
             response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
             job = self.wait_for_job(get_job_id(response))
-            result = job.result()
+            return job.result()
         else:
             payload = self._expectation_payload(prep_prog, operator_programs)
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
-            result = response.json()
-
-        if coefs is not None:
-            result = np.array(result)
-            return np.real_if_close(np.dot(result, coefs))
+            return response.json()
 
     def expectation_async(self, prep_prog, operator_programs=None):
         """

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -22,8 +22,7 @@ from itertools import product
 import numpy as np
 import copy
 from .quil import Program
-from .gates import H, RZ, RX, CNOT, X, PHASE
-from . import quilbase as pqb
+from .gates import H, RZ, RX, CNOT, X, PHASE, STANDARD_GATES
 from numbers import Number
 from collections import Sequence
 import warnings
@@ -124,6 +123,10 @@ class PauliTerm(object):
                 new_term.__dict__[key] = val
 
         return new_term
+
+    @property
+    def program(self):
+        return Program([STANDARD_GATES[gate](q) for q, gate in self])
 
     def get_qubits(self):
         """Gets all the qubits that this PauliTerm operates on.
@@ -575,6 +578,17 @@ class PauliSum(object):
                 like_terms[id] = like_terms[id] + [term]
 
         return coalesce(like_terms)
+
+    def get_programs(self):
+        """
+        Get a Pyquil Program corresponding to each term in the PauliSum and a coefficient
+        for each program
+
+        :return: (programs, coefficients)
+        """
+        programs = [term.program for term in self.terms]
+        coefficients = np.array([term.coefficient for term in self.terms])
+        return programs, coefficients
 
 
 def check_commutation(pauli_list, pauli_two):


### PR DESCRIPTION
This lets you write a simpler function to compute expectations for Paulis

```python

def qvm_expectation(prep_program, hamiltonian, cxn):
    progs, coefs = hamiltonian.get_programs()
    expect_coeffs = np.array(cxn.expectation(prep_program, operator_programs=progs))
    return np.real_if_close(np.dot(coefs, expect_coeffs))
```

cc #261 

see reverted commit b4cd63c in this PR where I started to hack the `QVMConnection.expectation()` method before realizing it was starting to get hairy.