### PR TITLE
Remove dangling input from commuting_set method

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -617,7 +617,7 @@ def check_commutation(pauli_list, pauli_two):
     return True
 
 
-def commuting_sets(pauli_terms, nqubits):
+def commuting_sets(pauli_terms):
     """Gather the Pauli terms of pauli_terms variable into commuting sets
 
     Uses algorithm defined in (Raeisi, Wiebe, Sanders, arXiv:1108.4318, 2011)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -467,7 +467,7 @@ def test_commuting_sets():
     term2 = PauliTerm("Y", 0) * PauliTerm("Y", 1)
     term3 = PauliTerm("Y", 0) * PauliTerm("Z", 2)
     pauli_sum = term1 + term2 + term3
-    commuting_sets(pauli_sum, 3)
+    commuting_sets(pauli_sum)
 
 
 def test_paulisum_iteration():


### PR DESCRIPTION
Removes number of qubits input for the `commuting_set` method in
pyquil.paulis