### PR TITLE
job.estimated_time_left_in_queue() method, with use in QPU logging. Resolves #298.

### DIFF
--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -52,7 +52,10 @@ def wait_for_job(get_job_fn, ping_time=None, status_time=None):
 
         if status_time and count % int(status_time / ping_time) == 0:
             if job.is_queued():
-                print("job {} is currently queued at position {}".format(job.job_id, job.position_in_queue()))
+                print("job {} is currently queued at position {}. "
+                      "Estimated time until execution: {} seconds."
+                      .format(job.job_id, job.position_in_queue(),
+                              job.estimated_time_left_in_queue()))
             elif job.is_running():
                 print("job {} is currently running".format(job.job_id))
 

--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -21,6 +21,7 @@ from pyquil.api.errors import CancellationError, QVMError, QPUError
 from pyquil.parser import parse_program
 from pyquil.wavefunction import Wavefunction
 
+ROUND_TRIP_JOB_TIME = 3. # 3 second average round trip job time.
 
 class Job(object):
     """
@@ -91,6 +92,14 @@ class Job(object):
         """
         if self.is_queued():
             return int(self._raw['position_in_queue'])
+
+    def estimated_time_left_in_queue(self):
+        """
+        If the job is queued, this will return how much time left is estimated
+        before execution.
+        """
+        if self.is_queued():
+            return ROUND_TRIP_JOB_TIME * self.position_in_queue()
 
     def get(self):
         warnings.warn("""

--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -96,7 +96,7 @@ class Job(object):
 
     def estimated_time_left_in_queue(self):
         """
-        If the job is queued, this will return how much time left is estimated
+        If the job is queued, this will return how much time left (in seconds) is estimated
         before execution.
         """
         if self.is_queued():

--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -21,7 +21,8 @@ from pyquil.api.errors import CancellationError, QVMError, QPUError
 from pyquil.parser import parse_program
 from pyquil.wavefunction import Wavefunction
 
-ROUND_TRIP_JOB_TIME = 3. # 3 second average round trip job time.
+ROUND_TRIP_JOB_TIME = 3.  # 3 second average round trip job time.
+
 
 class Job(object):
     """


### PR DESCRIPTION
`job.estimated_time_left_in_queue()` method, using an average roundtrip time of `3` seconds, and the current place in the queue. Modified queued job log message in `qpu.run_and_measure` to include time estimate. Resolves #298.