### PR TITLE
Refactored apply_noise_model and helpers

### DIFF
--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -304,7 +304,7 @@ NOISY_GATES = {
                             "NOISY-RX-MINUS-90"),
     ("RX", (np.pi,)): (np.array([[0, -1j],
                                  [-1j, 0]]),
-                            "NOISY-RX-PLUS-180"),
+                       "NOISY-RX-PLUS-180"),
     ("CZ", ()): (np.diag([1, 1, 1, -1]), "NOISY-CZ"),
 }
 

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -305,6 +305,9 @@ NOISY_GATES = {
     ("RX", (np.pi,)): (np.array([[0, -1j],
                                  [-1j, 0]]),
                        "NOISY-RX-PLUS-180"),
+    ("RX", (-np.pi,)): (np.array([[0, 1j],
+                                  [1j, 0]]),
+                       "NOISY-RX-MINUS-180"),
     ("CZ", ()): (np.diag([1, 1, 1, -1]), "NOISY-CZ"),
 }
 

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -307,7 +307,7 @@ NOISY_GATES = {
                        "NOISY-RX-PLUS-180"),
     ("RX", (-np.pi,)): (np.array([[0, 1j],
                                   [1j, 0]]),
-                       "NOISY-RX-MINUS-180"),
+                        "NOISY-RX-MINUS-180"),
     ("CZ", ()): (np.diag([1, 1, 1, -1]), "NOISY-CZ"),
 }
 


### PR DESCRIPTION
Currently applying an arbitrary noise model to a program expressed in the natural gateset is broken. This PR fixes this.