### PR TITLE
add priority named argument to job submission routines

### DIFF
--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -89,20 +89,21 @@ class CompilerConnection(object):
         elif specs_source is not None:
             raise TypeError('specs_source argument must be a Specs.')
 
-    def compile(self, quil_program):
+    def compile(self, quil_program, priority=0):
         """
         Sends a Quil program to the Forest compiler and returns the resulting
         compiled Program.
 
         :param Program quil_program: Quil program to be compiled.
         :param ISA isa: ISA to target.
+        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
         :returns: The compiled Program object.
         :rtype: Program
         """
         payload = self._compile_payload(quil_program)
         if self.use_queue:
             response = post_json(self.session, self.async_endpoint + "/job",
-                                 {"machine": "QUILC", "program": payload})
+                                 {"machine": "QUILC", "program": payload, "priority": priority})
             job = self.wait_for_job(get_job_id(response))
             return job.compiled_quil()
         else:
@@ -110,7 +111,7 @@ class CompilerConnection(object):
                                  payload)
             return parse_program(response.json()['compiled-quil'])
 
-    def compile_async(self, quil_program):
+    def compile_async(self, quil_program, priority=0):
         """
         Similar to compile except that it returns a job id and doesn't wait for
         the program to be executed.
@@ -118,7 +119,7 @@ class CompilerConnection(object):
         """
         payload = self._compile_payload(quil_program)
         response = post_json(self.session, self.async_endpoint + "/job",
-                             {"machine": "QUILC", "program": payload})
+                             {"machine": "QUILC", "program": payload, "priority": priority})
         return get_job_id(response)
 
     def _compile_payload(self, quil_program):

--- a/pyquil/api/qpu.py
+++ b/pyquil/api/qpu.py
@@ -222,6 +222,7 @@ with the former, the device.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, specifies a custom ISA to compile to. If left unset,
                     Forest uses the default ISA associated to this QPU device.
+        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
         :return: A list of a list of classical registers (each register contains a bit)
         :rtype: list
         """

--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -105,7 +105,7 @@ programs run on this QVM.
     def ping(self):
         raise DeprecationWarning("ping() function is deprecated")
 
-    def run(self, quil_program, classical_addresses, trials=1, needs_compilation=False, isa=None):
+    def run(self, quil_program, classical_addresses, trials=1, needs_compilation=False, isa=None, priority=0):
         """
         Run a Quil program multiple times, accumulating the values deposited in
         a list of classical addresses.
@@ -115,6 +115,7 @@ programs run on this QVM.
         :param int trials: Number of shots to collect.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
+        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
         :return: A list of lists of bits. Each sublist corresponds to the values
                  in `classical_addresses`.
         :rtype: list
@@ -124,20 +125,20 @@ programs run on this QVM.
             if needs_compilation and not self.use_queue:
                 warnings.warn('Synchronous QVM connection does not support compilation preprocessing. Running this job over the asynchronous endpoint, as if use_queue were set to True.')
 
-            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
             job = self.wait_for_job(get_job_id(response))
             return job.result()
         else:
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
             return response.json()
 
-    def run_async(self, quil_program, classical_addresses, trials=1, needs_compilation=False, isa=None):
+    def run_async(self, quil_program, classical_addresses, trials=1, needs_compilation=False, isa=None, priority=0):
         """
         Similar to run except that it returns a job id and doesn't wait for the program to be executed.
         See https://go.rigetti.com/connections for reasons to use this method.
         """
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation, isa)
-        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
         return get_job_id(response)
 
     def _run_payload(self, quil_program, classical_addresses, trials, needs_compilation, isa):
@@ -167,7 +168,7 @@ programs run on this QVM.
 
         return payload
 
-    def run_and_measure(self, quil_program, qubits, trials=1, needs_compilation=False, isa=None):
+    def run_and_measure(self, quil_program, qubits, trials=1, needs_compilation=False, isa=None, priority=0):
         """
         Run a Quil program once to determine the final wavefunction, and measure multiple times.
 
@@ -182,6 +183,7 @@ programs run on this QVM.
         :param int trials: Number of shots to collect.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
+        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
         :return: A list of a list of bits.
         :rtype: list
         """
@@ -190,20 +192,20 @@ programs run on this QVM.
             if needs_compilation and not self.use_queue:
                 warnings.warn('Synchronous QVM connection does not support compilation preprocessing. Running this job over the asynchronous endpoint, as if use_queue were set to True.')
 
-            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
             job = self.wait_for_job(get_job_id(response))
             return job.result()
         else:
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
             return response.json()
 
-    def run_and_measure_async(self, quil_program, qubits, trials=1, needs_compilation=False, isa=None):
+    def run_and_measure_async(self, quil_program, qubits, trials=1, needs_compilation=False, isa=None, priority=0):
         """
         Similar to run_and_measure except that it returns a job id and doesn't wait for the program to be executed.
         See https://go.rigetti.com/connections for reasons to use this method.
         """
         payload = self._run_and_measure_payload(quil_program, qubits, trials, needs_compilation, isa)
-        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
         return get_job_id(response)
 
     def _run_and_measure_payload(self, quil_program, qubits, trials, needs_compilation, isa):
@@ -233,7 +235,7 @@ programs run on this QVM.
 
         return payload
 
-    def wavefunction(self, quil_program, classical_addresses=None, needs_compilation=False, isa=None):
+    def wavefunction(self, quil_program, classical_addresses=None, needs_compilation=False, isa=None, priority=0):
         """
         Simulate a Quil program and get the wavefunction back.
 
@@ -247,6 +249,7 @@ programs run on this QVM.
         :param list|range classical_addresses: An optional list of classical addresses.
         :param needs_compilation: If True, preprocesses the job with the compiler.
         :param isa: If set, compiles to this target ISA.
+        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
         :return: A tuple whose first element is a Wavefunction object,
                  and whose second element is the list of classical bits corresponding
                  to the classical addresses.
@@ -260,7 +263,7 @@ programs run on this QVM.
                 warnings.warn('Synchronous QVM connection does not support compilation preprocessing. Running this job over the asynchronous endpoint, as if use_queue were set to True.')
 
             payload = self._wavefunction_payload(quil_program, classical_addresses, needs_compilation, isa)
-            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
             job = self.wait_for_job(get_job_id(response))
             return job.result()
         else:
@@ -268,7 +271,7 @@ programs run on this QVM.
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
             return Wavefunction.from_bit_packed_string(response.content, classical_addresses)
 
-    def wavefunction_async(self, quil_program, classical_addresses=None, needs_compilation=False, isa=None):
+    def wavefunction_async(self, quil_program, classical_addresses=None, needs_compilation=False, isa=None, priority=0):
         """
         Similar to wavefunction except that it returns a job id and doesn't wait for the program to be executed.
         See https://go.rigetti.com/connections for reasons to use this method.
@@ -277,7 +280,7 @@ programs run on this QVM.
             classical_addresses = []
 
         payload = self._wavefunction_payload(quil_program, classical_addresses, needs_compilation, isa)
-        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
         return get_job_id(response)
 
     def _wavefunction_payload(self, quil_program, classical_addresses, needs_compilation, isa):
@@ -301,7 +304,7 @@ programs run on this QVM.
 
         return payload
 
-    def expectation(self, prep_prog, operator_programs=None, needs_compilation=False, isa=None):
+    def expectation(self, prep_prog, operator_programs=None, needs_compilation=False, isa=None, priority=0):
         """
         Calculate the expectation value of operators given a state prepared by
         prep_program.
@@ -316,6 +319,7 @@ programs run on this QVM.
         :param list operator_programs: A list of PauliTerms. Default is Identity operator.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
+        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
         :returns: Expectation value of the operators.
         :rtype: float
         """
@@ -323,7 +327,7 @@ programs run on this QVM.
             raise TypeError("Expectation QVM programs do not support compilation preprocessing.  Make a separate CompilerConnection job first.")
         if self.use_queue:
             payload = self._expectation_payload(prep_prog, operator_programs)
-            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+            response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
             job = self.wait_for_job(get_job_id(response))
             return job.result()
         else:
@@ -331,7 +335,7 @@ programs run on this QVM.
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
             return response.json()
 
-    def expectation_async(self, prep_prog, operator_programs=None, needs_compilation=False, isa=None):
+    def expectation_async(self, prep_prog, operator_programs=None, needs_compilation=False, isa=None, priority=0):
         """
         Similar to expectation except that it returns a job id and doesn't wait for the program to be executed.
         See https://go.rigetti.com/connections for reasons to use this method.
@@ -340,7 +344,7 @@ programs run on this QVM.
             raise TypeError("Expectation QVM programs do not support compilation preprocessing.  Make a separate CompilerConnection job first.")
 
         payload = self._expectation_payload(prep_prog, operator_programs)
-        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
+        response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload, "priority": priority})
         return get_job_id(response)
 
     def _expectation_payload(self, prep_prog, operator_programs):

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -149,6 +149,7 @@ def test_job_run():
     def mock_queued_response(request, context):
         assert json.loads(request.text) == {
             "machine": "QVM",
+            "priority": 0,
             "program": program
         }
         return json.dumps({"jobId": JOB_ID, "status": "QUEUED"})
@@ -175,6 +176,7 @@ def test_async_wavefunction():
     def mock_queued_response(request, context):
         assert json.loads(request.text) == {
             "machine": "QVM",
+            "priority": 0,
             "program": program
         }
         return json.dumps({"jobId": JOB_ID, "status": "QUEUED"})
@@ -222,6 +224,7 @@ def test_qpu_connection(test_device):
     def mock_queued_response_run(request, context):
         assert json.loads(request.text) == {
             "machine": "QPU",
+            "priority": 0,
             "program": run_program,
             "device": "test_device"
         }
@@ -260,6 +263,7 @@ def test_qpu_connection(test_device):
     def mock_queued_response_run_and_measure(request, context):
         assert json.loads(request.text) == {
             "machine": "QPU",
+            "priority": 0,
             "program": run_and_measure_program,
             "device": "test_device"
         }
@@ -360,6 +364,7 @@ def test_job_compile():
     def mock_queued_response(request, context):
         assert json.loads(request.text) == {
             "machine": "QUILC",
+            "priority": 0,
             "program": processed_program
         }
         return json.dumps({"jobId": JOB_ID, "status": "QUEUED"})


### PR DESCRIPTION
This commit allows a user to submit jobs with lower execution priority, suitable for those running continuous integration tests who do not want to block active users.