### PR TITLE
Bugfix/add rx pi to xhalves gates

### DIFF
--- a/pyquil/device.py
+++ b/pyquil/device.py
@@ -139,6 +139,8 @@ def gates_in_isa(isa):
                 Gate("I", [], [unpack_qubit(q.id)]),
                 Gate("RX", [np.pi / 2], [unpack_qubit(q.id)]),
                 Gate("RX", [-np.pi / 2], [unpack_qubit(q.id)]),
+                Gate("RX", [np.pi], [unpack_qubit(q.id)]),
+                Gate("RX", [-np.pi], [unpack_qubit(q.id)]),
                 Gate("RZ", [THETA], [unpack_qubit(q.id)]),
             ])
         else:  # pragma no coverage

--- a/pyquil/tests/test_device.py
+++ b/pyquil/tests/test_device.py
@@ -241,7 +241,7 @@ def test_gates_in_isa(isa_dict):
     isa = ISA.from_dict(isa_dict)
     gates = gates_in_isa(isa)
     for q in [0, 1, 2]:
-        for g in [I, RX(np.pi / 2), RX(-np.pi / 2), RZ(THETA)]:
+        for g in [I, RX(np.pi / 2), RX(-np.pi / 2), RX(np.pi), RX(-np.pi), RZ(THETA)]:
             assert g(q) in gates
 
     assert CZ(0, 1) in gates


### PR DESCRIPTION
This is necessary for running the spec-based noise model generation tool