### PR TITLE
job prioritization round 2

### DIFF
--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -96,7 +96,7 @@ class CompilerConnection(object):
 
         :param Program quil_program: Quil program to be compiled.
         :param ISA isa: ISA to target.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :returns: The compiled Program object.
         :rtype: Program
         """

--- a/pyquil/api/qpu.py
+++ b/pyquil/api/qpu.py
@@ -172,7 +172,7 @@ with the former, the device.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, specifies a custom ISA to compile to. If left unset,
                     Forest uses the default ISA associated to this QPU device.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :return: A list of a list of classical registers (each register contains a bit)
         :rtype: list
         """
@@ -222,7 +222,7 @@ with the former, the device.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, specifies a custom ISA to compile to. If left unset,
                     Forest uses the default ISA associated to this QPU device.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :return: A list of a list of classical registers (each register contains a bit)
         :rtype: list
         """

--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -115,7 +115,7 @@ programs run on this QVM.
         :param int trials: Number of shots to collect.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :return: A list of lists of bits. Each sublist corresponds to the values
                  in `classical_addresses`.
         :rtype: list
@@ -183,7 +183,7 @@ programs run on this QVM.
         :param int trials: Number of shots to collect.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :return: A list of a list of bits.
         :rtype: list
         """
@@ -249,7 +249,7 @@ programs run on this QVM.
         :param list|range classical_addresses: An optional list of classical addresses.
         :param needs_compilation: If True, preprocesses the job with the compiler.
         :param isa: If set, compiles to this target ISA.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :return: A tuple whose first element is a Wavefunction object,
                  and whose second element is the list of classical bits corresponding
                  to the classical addresses.
@@ -319,7 +319,7 @@ programs run on this QVM.
         :param list operator_programs: A list of PauliTerms. Default is Identity operator.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
-        :param int priority: Sets a desired priority for the job. Larger numbers are lower priority, default is 0 (highest priority available to average user).
+        :param int priority: Sets a desired priority for the job. Larger numbers are higher priority, default is 0 (highest priority available to average user).
         :returns: Expectation value of the operators.
         :rtype: float
         """


### PR DESCRIPTION
The previous PR had incorrect docstrings. Higher priority values mean faster execution, the opposite of `nice`.