### PR TITLE
Fix shift_quantum_gates

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -608,6 +608,7 @@ def shift_quantum_gates(program, shift_offset):
     shifted_program.inst(program)
     for instruct in shifted_program:
         if isinstance(instruct, Gate):
-            for qubit in instruct.qubits:
-                qubit.index += shift_offset
+            # Make a copy to avoid weird behavior
+            new_qubs = [Qubit(q.index + shift_offset) for q in instruct.qubits]
+            instruct.qubits = new_qubs
     return shifted_program

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -24,6 +24,7 @@ from pyquil.gates import I, X, Y, Z, H, T, S, RX, RY, RZ, CNOT, CCNOT, PHASE, CP
     CPHASE10, CPHASE, SWAP, CSWAP, ISWAP, PSWAP, MEASURE, HALT, WAIT, NOP, RESET, \
     TRUE, FALSE, NOT, AND, OR, MOVE, EXCHANGE
 from pyquil.parameters import Parameter, quil_sin, quil_cos
+from pyquil.paulis import exponential_map, sZ
 from pyquil.quil import Program, merge_programs, shift_quantum_gates
 from pyquil.quilbase import DefGate, Gate, Addr, Qubit, JumpWhen
 
@@ -440,6 +441,22 @@ def test_prog_merge():
 def test_quantum_gate_shift():
     prog = Program(X(0), CNOT(0, 4), MEASURE(5, [5]))
     assert shift_quantum_gates(prog, 5) == Program(X(5), CNOT(5, 9), MEASURE(5, [5]))
+
+
+def test_quantum_gate_shift_doesnt_modify_program():
+    prog = exponential_map(sZ(0) * sZ(1))(1.0)
+    out1 = prog.out()
+    _ = shift_quantum_gates(prog, 1)
+    out2 = prog.out()
+    assert out1 == out2
+
+
+def test_quantum_gate_shift_doesnt_double_shift():
+    prog = exponential_map(sZ(0) * sZ(1))(1.0)
+    new_prog = shift_quantum_gates(prog, 1)
+    for inst in new_prog:
+        for qub in inst.qubits:
+            assert qub.index in [1, 2]
 
 
 def test_get_qubits():


### PR DESCRIPTION
This was very broken (see tests). Often a qubit index would be shifted multiple times