### PR TITLE
Allow PauliTerm qubit indices to be numpy.int{8,16,32,64}

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -26,7 +26,7 @@ from .gates import H, RZ, RX, CNOT, X, PHASE, STANDARD_GATES
 from numbers import Number
 from collections import Sequence
 import warnings
-from six import integer_types
+from six import integer_types as six_integer_types
 from six.moves import range
 
 PAULI_OPS = ["X", "Y", "Z", "I"]
@@ -45,6 +45,10 @@ PAULI_COEFF = {'ZZ': 1.0, 'YY': 1.0, 'XX': 1.0, 'II': 1.0,
 class UnequalLengthWarning(Warning):
     def __init__(self, *args, **kwargs):
         super(UnequalLengthWarning, self).__init__(*args, **kwargs)
+
+
+integer_types = six_integer_types + (np.int64, np.int32, np.int16, np.int8)
+"""Explicitly include numpy integer dtypes (for python 3)."""
 
 
 class PauliTerm(object):

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -561,3 +561,10 @@ def test_from_list():
     with pytest.raises(ValueError):
         # terms are not on disjoint qubits
         pterm = PauliTerm.from_list([("X", 0), ("Y", 0)])
+
+
+def test_numpy_integer_types():
+    idx_np, = np.arange(1, dtype=np.int64)
+    assert isinstance(idx_np, np.int64)
+    # on python 3 this fails unless explicitly allowing for numpy integer types
+    PauliTerm("X", idx_np)


### PR DESCRIPTION
This fixes an annoying issue that crops up when constructing PauliTerm's with bespoke numpy integer type indices.