### PR TITLE
PauliTerms remember their qubit ordering

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+v1.9
+----
+
+ - :py:class:`PauliTerm` now remembers the order of its operations. ``sX(1)*sZ(2)`` will compile
+   to different Quil code than ``sZ(2)*sX(1)``, although the terms will still be equal according
+   to the ``__eq__`` method. :py:func:`PauliTerm.id()` will return a string representation of
+   the term's operations in the remembered order. To compare terms irrespective of operation
+   order, use :py:func:`PauliTerm.operations_as_set()`. During :py:class:`PauliSum` combination
+   of like terms, a warning will be emitted if two terms are combined that have different orders
+   of operation.

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -6,8 +6,10 @@ v1.9
 
  - :py:class:`PauliTerm` now remembers the order of its operations. ``sX(1)*sZ(2)`` will compile
    to different Quil code than ``sZ(2)*sX(1)``, although the terms will still be equal according
-   to the ``__eq__`` method. :py:func:`PauliTerm.id()` will return a string representation of
-   the term's operations in the remembered order. To compare terms irrespective of operation
-   order, use :py:func:`PauliTerm.operations_as_set()`. During :py:class:`PauliSum` combination
+   to the ``__eq__`` method. During :py:class:`PauliSum` combination
    of like terms, a warning will be emitted if two terms are combined that have different orders
    of operation.
+ - :py:func:`PauliTerm.id()` takes an optional argument ``sort_ops`` which defaults to True for
+   backwards compatibility. However, this function should not be used for comparing term-type like
+   it has been used previously. Use :py:func:`PauliTerm.operations_as_set()` instead. In the future,
+   ``sort_ops`` will default to False and will eventually be removed.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,6 +56,7 @@ Contents
    compiler
    noise
    modules
+   changes
 
 
 Indices and Tables

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -93,7 +93,7 @@ class PauliTerm(object):
         :rtype: string
         """
         if sort_ops and len(self._ops) > 1:
-            warnings.warn("This function will not work on PauliTerms where the qubits are not "
+            warnings.warn("`PauliTerm.id()` will not work on PauliTerms where the qubits are not "
                           "sortable and should be avoided in favor of `operations_as_set`.",
                           FutureWarning)
             return ''.join("{}{}".format(self._ops[q], q) for q in sorted(self._ops.keys()))

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -92,7 +92,7 @@ class PauliTerm(object):
         :return: A string representation of this term's operations.
         :rtype: string
         """
-        if sort_ops:
+        if sort_ops and len(self._ops) > 1:
             warnings.warn("This function will not work on PauliTerms where the qubits are not "
                           "sortable and should be avoided in favor of `operations_as_set`.",
                           FutureWarning)
@@ -638,6 +638,7 @@ def check_commutation(pauli_list, pauli_two):
     :returns: True if pauli_two object commutes with pauli_list, False otherwise
     :rtype: bool
     """
+
     def coincident_parity(p1, p2):
         non_similar = 0
         p1_indices = set(p1._ops.keys())
@@ -762,6 +763,7 @@ def _exponentiate_general_case(pauli_term, param):
     :returns: A Quil program object
     :rtype: Program
     """
+
     def reverse_hack(p):
         # A hack to produce a *temporary* program which reverses p.
         revp = Program()
@@ -821,7 +823,7 @@ def suzuki_trotter(trotter_order, trotter_steps):
               type: o=0 is A and o=1 is B.
     :rtype: list
     """
-    p1 = p2 = p4 = p5 = 1.0 / (4 - (4**(1. / 3)))
+    p1 = p2 = p4 = p5 = 1.0 / (4 - (4 ** (1. / 3)))
     p3 = 1 - 4 * p1
     trotter_dict = {1: [(1, 0), (1, 1)],
                     2: [(0.5, 0), (1, 1), (0.5, 0)],
@@ -880,7 +882,7 @@ def trotterize(first_pauli_term, second_pauli_term, trotter_order=1,
     if not (1 <= trotter_order < 5):
         raise ValueError("trotterize only accepts trotter_order in {1, 2, 3, 4}.")
 
-    commutator = (first_pauli_term * second_pauli_term) +\
+    commutator = (first_pauli_term * second_pauli_term) + \
                  (-1 * second_pauli_term * first_pauli_term)
 
     prog = Program()

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -590,7 +590,6 @@ class PauliSum(object):
         """
         return simplify_pauli_sum(self)
 
-
     def get_programs(self):
         """
         Get a Pyquil Program corresponding to each term in the PauliSum and a coefficient

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -603,9 +603,15 @@ class PauliSum(object):
 
 
 def simplify_pauli_sum(pauli_sum):
-    like_terms = defaultdict(list)
+    # You might want to use a defaultdict(list) here, but don't because
+    # we want to do our best to preserve the order of terms.
+    like_terms = OrderedDict()
     for term in pauli_sum.terms:
-        like_terms[term.operations_as_set()].append(term)
+        key = term.operations_as_set()
+        if key in like_terms:
+            like_terms[key].append(term)
+        else:
+            like_terms[key] = [term]
 
     terms = []
     for term_list in like_terms.values():

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -117,8 +117,8 @@ class PauliTerm(object):
         elif isinstance(other, PauliSum):
             return other == self
         else:
-            return (self.operations_as_set() == other.operations_as_set()
-                    and np.isclose(self.coefficient, other.coefficient))
+            return (self.operations_as_set() == other.operations_as_set() and
+                    np.isclose(self.coefficient, other.coefficient))
 
     def __hash__(self):
         return hash((

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -79,9 +79,6 @@ class PauliTerm(object):
             raise ValueError("coefficient of PauliTerm must be a Number.")
         self.coefficient = complex(coefficient)
 
-    def is_identity(self):
-        return len(self._ops) == 0
-
     def id(self, sort_ops=True):
         """
         Returns an identifier string for the PauliTerm (ignoring the coefficient).

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -86,7 +86,7 @@ class PauliTerm(object):
         Don't use this to compare terms. This function will not work with qubits that
         aren't sortable.
 
-        :param sort_ops: Whether to sort to operations by qubit. This is True by default for
+        :param sort_ops: Whether to sort operations by qubit. This is True by default for
             backwards compatibility but will change in pyQuil 2.0. Callers should never rely
             on comparing id's for testing equality. See ``operations_as_set`` instead.
         :return: A string representation of this term's operations.

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -79,6 +79,9 @@ class PauliTerm(object):
             raise ValueError("coefficient of PauliTerm must be a Number.")
         self.coefficient = complex(coefficient)
 
+    def is_identity(self):
+        return len(self._ops) == 0
+
     def id(self, sort_ops=True):
         """
         Returns an identifier string for the PauliTerm (ignoring the coefficient).

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -16,11 +16,10 @@
 """
 Module for creating and defining Quil programs.
 """
-import itertools
-import types
 import warnings
-from collections import OrderedDict
+from itertools import count
 from math import pi
+import types
 
 import numpy as np
 from six import string_types

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -16,10 +16,11 @@
 """
 Module for creating and defining Quil programs.
 """
-import warnings
-from itertools import count
-from math import pi
+import itertools
 import types
+import warnings
+from collections import OrderedDict
+from math import pi
 
 import numpy as np
 from six import string_types

--- a/pyquil/tests/test_parametric.py
+++ b/pyquil/tests/test_parametric.py
@@ -163,4 +163,10 @@ def test_exponentiate_paraprog():
     xterm = PauliTerm("X", 2) * PauliTerm("X", 1)
     paraprog = exponential_map(xterm)
     prog = paraprog(1)
-    assert prog.out() == "H 1\nH 2\nCNOT 1 2\nRZ(2.0) 2\nCNOT 1 2\nH 1\nH 2\n"
+    assert prog.out() == ("H 2\n"
+                          "H 1\n"
+                          "CNOT 2 1\n"
+                          "RZ(2.0) 1\n"
+                          "CNOT 2 1\n"
+                          "H 2\n"
+                          "H 1\n")

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -16,6 +16,7 @@
 ##############################################################################
 
 import math
+import warnings
 from functools import reduce
 from itertools import product
 from operator import mul
@@ -473,6 +474,15 @@ def test_is_identity_2():
     assert not t.is_identity()
 
 
+def _commutator(t1, t2):
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore',
+                                message=r"The term .+ will be combined with .+, "
+                                        r"but they have different orders of operations.*",
+                                category=UserWarning)
+        return t1 * t2 + -1 * t2 * t1
+
+
 def test_check_commutation_rigorous():
     # more rigorous test.  Get all operators in Pauli group
     p_n_group = ("I", "X", "Y", "Z")
@@ -480,15 +490,12 @@ def test_check_commutation_rigorous():
     pauli_ops = [list(zip(x, range(3))) for x in pauli_list]
     pauli_ops_pq = [reduce(mul, (PauliTerm(*x) for x in op)) for op in pauli_ops]
 
-    def commutator(t1, t2):
-        return t1 * t2 + -1 * t2 * t1
-
     non_commuting_pairs = []
     commuting_pairs = []
     for x in range(len(pauli_ops_pq)):
         for y in range(x, len(pauli_ops_pq)):
 
-            tmp_op = commutator(pauli_ops_pq[x], pauli_ops_pq[y])
+            tmp_op = _commutator(pauli_ops_pq[x], pauli_ops_pq[y])
             assert len(tmp_op.terms) == 1
             if tmp_op.terms[0].is_identity():
                 commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -93,8 +93,8 @@ def test_simplify_term_xz():
 
 
 def test_simplify_term_multindex():
-    term = (PauliTerm('X', 0, coefficient=-0.5) * PauliTerm('Z', 0, coefficient=-1.0)
-            * PauliTerm('X', 2, 0.5))
+    term = (PauliTerm('X', 0, coefficient=-0.5) *
+            PauliTerm('Z', 0, coefficient=-1.0) * PauliTerm('X', 2, 0.5))
     assert term.id() == 'Y0X2'
     assert term.coefficient == -0.25j
 
@@ -341,10 +341,10 @@ def test_exponentiate_3cob():
 
 def test_exponentiate_3ns():
     # testing circuit for 3-terms non-sequential
-    generator = (PauliTerm("Y", 0, 1.0)
-                 * PauliTerm("I", 1, 1.0)
-                 * PauliTerm("Y", 2, 1.0)
-                 * PauliTerm("Y", 3, 1.0))
+    generator = (PauliTerm("Y", 0, 1.0) *
+                 PauliTerm("I", 1, 1.0) *
+                 PauliTerm("Y", 2, 1.0) *
+                 PauliTerm("Y", 3, 1.0))
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([RX(math.pi / 2.0)(0), RX(math.pi / 2.0)(2),

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -163,6 +163,13 @@ def test_ids():
     assert term_1.id() == term_2.id()
 
 
+def test_ids_no_sort():
+    term_1 = PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0) * PauliTerm("X", 5, 5)
+    term_2 = PauliTerm("X", 5, 5) * PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0)
+    assert term_1.id(sort_ops=False) == 'Z0Z1X5'
+    assert term_2.id(sort_ops=False) == 'X5Z0Z1'
+
+
 def test_pauliop_inputs():
     with pytest.raises(AssertionError):
         PauliTerm('X', -2)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -233,7 +233,7 @@ def test_ps_sub():
     b = 1.0 - sX(0)
     assert str(b) == "(1+0j)*I + (-1+0j)*X0"
     b = sX(0) - 1.0
-    assert str(b) == "(-1+0j)*I + (1+0j)*X0"
+    assert str(b) == "(1+0j)*X0 + (-1+0j)*I"
 
 
 def test_zero_terms():

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -459,6 +459,21 @@ def test_check_commutation():
     assert check_commutation([term2], term3)
     assert not check_commutation([term1], term3)
 
+
+def test_is_identity():
+    t = PauliTerm("I", 5, 1.4)
+    assert t.is_identity()
+
+
+def test_is_identity_2():
+    t = sZ(0) * sZ(0)
+    assert t.is_identity()
+
+    t = sZ(0)
+    assert not t.is_identity()
+
+
+def test_check_commutation_rigorous():
     # more rigorous test.  Get all operators in Pauli group
     p_n_group = ("I", "X", "Y", "Z")
     pauli_list = list(product(p_n_group, repeat=3))
@@ -475,7 +490,7 @@ def test_check_commutation():
 
             tmp_op = commutator(pauli_ops_pq[x], pauli_ops_pq[y])
             assert len(tmp_op.terms) == 1
-            if tmp_op.terms[0].id() == '':
+            if tmp_op.terms[0].is_identity():
                 commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))
             else:
                 non_commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -28,7 +28,7 @@ from six.moves import range
 from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
 from pyquil.paulis import PauliTerm, PauliSum, exponential_map, exponentiate_commuting_pauli_sum, \
     ID, UnequalLengthWarning, exponentiate, trotterize, is_zero, check_commutation, commuting_sets, \
-    term_with_coeff, sI, sX, sY, sZ, ZERO
+    term_with_coeff, sI, sX, sY, sZ, ZERO, is_identity
 from pyquil.quil import Program
 
 
@@ -461,19 +461,6 @@ def test_check_commutation():
     assert not check_commutation([term1], term3)
 
 
-def test_is_identity():
-    t = PauliTerm("I", 5, 1.4)
-    assert t.is_identity()
-
-
-def test_is_identity_2():
-    t = sZ(0) * sZ(0)
-    assert t.is_identity()
-
-    t = sZ(0)
-    assert not t.is_identity()
-
-
 def _commutator(t1, t2):
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
@@ -497,7 +484,7 @@ def test_check_commutation_rigorous():
 
             tmp_op = _commutator(pauli_ops_pq[x], pauli_ops_pq[y])
             assert len(tmp_op.terms) == 1
-            if tmp_op.terms[0].is_identity():
+            if is_identity(tmp_op.terms[0]):
                 commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))
             else:
                 non_commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -160,7 +160,9 @@ def test_getitem():
 def test_ids():
     term_1 = PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0) * PauliTerm("X", 5, 5)
     term_2 = PauliTerm("X", 5, 5) * PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0)
-    assert term_1.id() == term_2.id()
+    with pytest.warns(FutureWarning) as w:
+        assert term_1.id() == term_2.id()
+    assert 'should be avoided' in str(w[0])
 
 
 def test_ids_no_sort():

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -160,8 +160,7 @@ def test_getitem():
 def test_ids():
     term_1 = PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0) * PauliTerm("X", 5, 5)
     term_2 = PauliTerm("X", 5, 5) * PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0)
-    assert term_1.id() == "Z0Z1X5"
-    assert term_2.id() == "X5Z0Z1"
+    assert term_1.id() == term_2.id()
 
 
 def test_pauliop_inputs():
@@ -215,7 +214,7 @@ def test_ps_adds_pt_2():
     assert str(b + 1.0) == "(3+0j)*I"
     assert str(1.0 + b) == "(3+0j)*I"
     b = sX(0) + 1.0
-    assert str(b) == "(1+0j)*I + (1+0j)*X0"
+    assert str(b) == "(1+0j)*X0 + (1+0j)*I"
     b = 1.0 + sX(0)
     assert str(b) == "(1+0j)*I + (1+0j)*X0"
 

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -95,7 +95,7 @@ def test_simplify_term_xz():
 def test_simplify_term_multindex():
     term = (PauliTerm('X', 0, coefficient=-0.5) *
             PauliTerm('Z', 0, coefficient=-1.0) * PauliTerm('X', 2, 0.5))
-    assert term.id() == 'Y0X2'
+    assert term.id(sort_ops=False) == 'Y0X2'
     assert term.coefficient == -0.25j
 
 

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -341,12 +341,10 @@ def test_exponentiate_3cob():
 
 def test_exponentiate_3ns():
     # testing circuit for 3-terms non-sequential
-    generator = (
-            PauliTerm("Y", 0, 1.0)
-            * PauliTerm("I", 1, 1.0)
-            * PauliTerm("Y", 2, 1.0)
-            * PauliTerm("Y", 3, 1.0)
-    )
+    generator = (PauliTerm("Y", 0, 1.0)
+                 * PauliTerm("I", 1, 1.0)
+                 * PauliTerm("Y", 2, 1.0)
+                 * PauliTerm("Y", 3, 1.0))
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([RX(math.pi / 2.0)(0), RX(math.pi / 2.0)(2),

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -170,6 +170,12 @@ def test_ids_no_sort():
     assert term_2.id(sort_ops=False) == 'X5Z0Z1'
 
 
+def test_operations_as_set():
+    term_1 = PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0) * PauliTerm("X", 5, 5)
+    term_2 = PauliTerm("X", 5, 5) * PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0)
+    assert term_1.operations_as_set() == term_2.operations_as_set()
+
+
 def test_pauliop_inputs():
     with pytest.raises(AssertionError):
         PauliTerm('X', -2)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -15,20 +15,20 @@
 #    limitations under the License.
 ##############################################################################
 
-import pytest
-from pyquil.paulis import (PauliTerm, PauliSum, exponential_map, exponentiate_commuting_pauli_sum,
-                           ID, UnequalLengthWarning, exponentiate, trotterize, is_zero,
-                           check_commutation, commuting_sets, term_with_coeff, sI, sX, sY,
-                           sZ, ZERO)
-from pyquil.quil import Program
-from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
-
 import math
-from itertools import product
 from functools import reduce
+from itertools import product
 from operator import mul
-from six.moves import range
+
 import numpy as np
+import pytest
+from six.moves import range
+
+from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
+from pyquil.paulis import PauliTerm, PauliSum, exponential_map, exponentiate_commuting_pauli_sum, \
+    ID, UnequalLengthWarning, exponentiate, trotterize, is_zero, check_commutation, commuting_sets, \
+    term_with_coeff, sI, sX, sY, sZ, ZERO
+from pyquil.quil import Program
 
 
 def isclose(a, b, rel_tol=1e-10, abs_tol=0.0):
@@ -93,8 +93,8 @@ def test_simplify_term_xz():
 
 
 def test_simplify_term_multindex():
-    term = PauliTerm('X', 0, coefficient=-0.5) * PauliTerm('Z', 0, coefficient=-1.0) \
-        * PauliTerm('X', 2, 0.5)
+    term = (PauliTerm('X', 0, coefficient=-0.5) * PauliTerm('Z', 0, coefficient=-1.0)
+            * PauliTerm('X', 2, 0.5))
     assert term.id() == 'Y0X2'
     assert term.coefficient == -0.25j
 
@@ -160,7 +160,8 @@ def test_getitem():
 def test_ids():
     term_1 = PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0) * PauliTerm("X", 5, 5)
     term_2 = PauliTerm("X", 5, 5) * PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0)
-    assert term_1.id() == term_2.id()
+    assert term_1.id() == "Z0Z1X5"
+    assert term_2.id() == "X5Z0Z1"
 
 
 def test_pauliop_inputs():
@@ -237,8 +238,7 @@ def test_ps_sub():
 
 
 def test_zero_terms():
-    term = PauliTerm("X", 0, 1.0) + PauliTerm("X", 0, -1.0) + \
-        PauliTerm("Y", 0, 0.5)
+    term = PauliTerm("X", 0, 1.0) + PauliTerm("X", 0, -1.0) + PauliTerm("Y", 0, 0.5)
     assert str(term) == "(0.5+0j)*Y0"
 
     term = PauliTerm("X", 0, 1.0) + PauliTerm("X", 0, -1.0)
@@ -254,14 +254,13 @@ def test_zero_terms():
     term4 = PauliSum([])
     assert str(term4) == "0j*I"
 
-    term = PauliSum([PauliTerm("X", 0, 0.0), PauliTerm("Y", 1, 1.0) *
-                     PauliTerm("Z", 2)])
+    term = PauliSum([PauliTerm("X", 0, 0.0), PauliTerm("Y", 1, 1.0) * PauliTerm("Z", 2)])
     assert str(term) == "0j*X0 + (1+0j)*Y1*Z2"
     term = term.simplify()
     assert str(term) == "(1+0j)*Y1*Z2"
 
 
-def test_exponentiate():
+def test_exponentiate_1():
     # test rotation of single qubit
     generator = PauliTerm("Z", 0, 1.0)
     para_prog = exponential_map(generator)
@@ -269,47 +268,57 @@ def test_exponentiate():
     result_prog = Program().inst(RZ(2.0)(0))
     assert prog == result_prog
 
+
+def test_exponentiate_2():
     # testing general 2-circuit
-    generator = PauliTerm("Z", 1, 1.0) * PauliTerm("Z", 0, 1.0)
+    generator = PauliTerm("Z", 0, 1.0) * PauliTerm("Z", 1, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst(CNOT(0, 1)).inst(RZ(2.0)(1)).inst(CNOT(0, 1))
     assert prog == result_prog
 
+
+def test_exponentiate_bp0_ZX():
     # testing change of basis position 0
-    generator = PauliTerm("Z", 1, 1.0) * PauliTerm("X", 0, 1.0)
+    generator = PauliTerm("X", 0, 1.0) * PauliTerm("Z", 1, 1.0)
     param_prog = exponential_map(generator)
     prog = param_prog(1)
-    result_prog = Program().inst([H(0), CNOT(0, 1), RZ(2.0)(1), CNOT(0, 1),
-                                  H(0)])
+    result_prog = Program().inst([H(0), CNOT(0, 1), RZ(2.0)(1), CNOT(0, 1), H(0)])
     assert prog == result_prog
 
+
+def test_exponentiate_bp1_XZ():
     # testing change of basis position 1
-    generator = PauliTerm("X", 1, 1.0) * PauliTerm("Z", 0, 1.0)
+    generator = PauliTerm("Z", 0, 1.0) * PauliTerm("X", 1, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([H(1), CNOT(0, 1), RZ(2.0)(1), CNOT(0, 1),
-                                  H(1)])
+    result_prog = Program().inst([H(1), CNOT(0, 1), RZ(2.0)(1), CNOT(0, 1), H(1)])
     assert prog == result_prog
 
+
+def test_exponentiate_bp0_ZY():
     # testing change of basis position 0
-    generator = PauliTerm("Z", 1, 1.0) * PauliTerm("Y", 0, 1.0)
+    generator = PauliTerm("Y", 0, 1.0) * PauliTerm("Z", 1, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([RX(math.pi / 2.0)(0), CNOT(0, 1), RZ(2.0)(1),
                                   CNOT(0, 1), RX(-math.pi / 2)(0)])
     assert prog == result_prog
 
+
+def test_exponentiate_bp1_YZ():
     # testing change of basis position 1
-    generator = PauliTerm("Y", 1, 1.0) * PauliTerm("Z", 0, 1.0)
+    generator = PauliTerm("Z", 0, 1.0) * PauliTerm("Y", 1, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([RX(math.pi / 2.0)(1), CNOT(0, 1), RZ(2.0)(1),
-                                  CNOT(0, 1), RX(-math.pi / 2.0)(1)])
+    result_prog = Program().inst([RX(math.pi / 2.0)(1), CNOT(0, 1),
+                                  RZ(2.0)(1), CNOT(0, 1), RX(-math.pi / 2.0)(1)])
     assert prog == result_prog
 
+
+def test_exponentiate_3cob():
     # testing circuit for 3-terms with change of basis
-    generator = PauliTerm("X", 2, 1.0) * PauliTerm("Y", 1, 1.0) * PauliTerm("Z", 0, 1.0)
+    generator = PauliTerm("Z", 0, 1.0) * PauliTerm("Y", 1, 1.0) * PauliTerm("X", 2, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([RX(math.pi / 2.0)(1), H(2), CNOT(0, 1),
@@ -317,10 +326,15 @@ def test_exponentiate():
                                   CNOT(0, 1), RX(-math.pi / 2.0)(1), H(2)])
     assert prog == result_prog
 
+
+def test_exponentiate_3ns():
     # testing circuit for 3-terms non-sequential
-    generator = PauliTerm("Y", 3, 1.0) * PauliTerm("Y", 2, 1.0) * PauliTerm("I", 1,
-                                                                            1.0) * PauliTerm("Y", 0,
-                                                                                             1.0)
+    generator = (
+            PauliTerm("Y", 0, 1.0)
+            * PauliTerm("I", 1, 1.0)
+            * PauliTerm("Y", 2, 1.0)
+            * PauliTerm("Y", 3, 1.0)
+    )
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([RX(math.pi / 2.0)(0), RX(math.pi / 2.0)(2),
@@ -563,8 +577,40 @@ def test_from_list():
         pterm = PauliTerm.from_list([("X", 0), ("Y", 0)])
 
 
+def test_ordered():
+    term = sZ(3) * sZ(2) * sZ(1)
+    prog = exponential_map(term)(0.5)
+    assert prog.out() == "CNOT 3 2\n" \
+                         "CNOT 2 1\n" \
+                         "RZ(1.0) 1\n" \
+                         "CNOT 2 1\n" \
+                         "CNOT 3 2\n"
+
+
 def test_numpy_integer_types():
     idx_np, = np.arange(1, dtype=np.int64)
     assert isinstance(idx_np, np.int64)
     # on python 3 this fails unless explicitly allowing for numpy integer types
     PauliTerm("X", idx_np)
+
+
+def test_simplify():
+    t1 = sZ(0) * sZ(1)
+    t2 = sZ(0) * sZ(1)
+    assert (t1 + t2) == 2 * sZ(0) * sZ(1)
+
+
+def test_dont_simplify():
+    t1 = sZ(0) * sZ(1)
+    t2 = sZ(2) * sZ(3)
+    assert (t1 + t2) != 2 * sZ(0) * sZ(1)
+
+
+def test_simplify_warning():
+    t1 = sZ(0) * sZ(1)
+    t2 = sZ(1) * sZ(0)
+    with pytest.warns(UserWarning) as e:
+        tsum = t1 + t2
+
+    assert tsum == 2 * sZ(0) * sZ(1)
+    assert str(e[0].message).startswith('The term Z1Z0 will be combined with Z0Z1')


### PR DESCRIPTION
See changelog and #355 for motivation.

In particular, this will be important for using QubitPlaceholder's cc #354 as well as for tailoring pyquil programs to physical devices. 

This PR attempts to keep as much behavior the same as possible. Pay close attention to the changes in the tests for what behaviour changes. It should only be in cases where a string is being generated... either the str() of a paulisum or a program resulting from exponentiating a pualisum