### PR TITLE
introduce and use QUILCError

### DIFF
--- a/pyquil/api/errors.py
+++ b/pyquil/api/errors.py
@@ -101,6 +101,16 @@ then please describe the problem in a GitHub issue at:
         super(QVMError, self).__init__(server_status, explanation)
 
 
+class QUILCError(ApiError):
+    def __init__(self, server_status):
+        explanation = """
+QUILC returned the above error. This could be due to a bug in the server or a
+bug in your code. If you suspect this to be a bug in pyQuil or Rigetti Forest,
+then please describe the problem in a GitHub issue at:
+    https://github.com/rigetticomputing/pyquil/issues"""
+        super(QUILCError, self).__init__(server_status, explanation)
+
+
 class TooManyQubitsError(ApiError):
     def __init__(self, server_status):
         explanation = """
@@ -133,5 +143,6 @@ error_mapping = {
     'invalid_user': InvalidUserError,
     'job_not_found': JobNotFoundError,
     'missing_permissions': MissingPermissionsError,
+    'quilc_error': QUILCError,
     'qvm_error': QVMError,
 }

--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -17,7 +17,7 @@
 import base64
 import warnings
 
-from pyquil.api.errors import CancellationError, QVMError, QPUError
+from pyquil.api.errors import CancellationError, QVMError, QPUError, QUILCError, UnknownApiError
 from pyquil.parser import parse_program
 from pyquil.wavefunction import Wavefunction
 
@@ -65,8 +65,12 @@ class Job(object):
         elif self._raw['status'] == 'ERROR':
             if self._machine == 'QVM':
                 raise QVMError(self._raw['result'])
-            else:  # self._machine == 'QPU'
+            elif self._machine == 'QPU':
                 raise QPUError(self._raw['result'])
+            elif self._machine == 'QUILC':
+                raise QUILCError(self._raw['result'])
+            else:
+                raise UnknownApiError(self._raw['result'])
 
         if self._raw['program']['type'] == 'wavefunction':
             return Wavefunction.from_bit_packed_string(


### PR DESCRIPTION
Allows for better handling of quilc exceptions occurring during async endpoint usage.

(I'm a little surprised that the QVM sync endpoint has no special error handling in pyQuil—but that's a separate PR for a separate day.)