### PR TITLE
Fix typos by replacing H|0> with Bell state

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -742,7 +742,7 @@ the obtained outcome and subsequently rescaled to unit norm.
     # This program prepares something called a Bell state (a special kind of "entangled state")
     bell_program = Program(H(0), CNOT(0, 1))
     wavefunction = quantum_simulator.wavefunction(bell_program)
-    print("Before measurement: H|0> = ", wavefunction)
+    print("Before measurement: Bell state = ", wavefunction)
 
     bell_program.measure(0, classical_reg)
     for x in range(5):
@@ -752,7 +752,7 @@ the obtained outcome and subsequently rescaled to unit norm.
 
 .. parsed-literal::
 
-    Before measurement: H|0> =  (0.7071067812+0j)|00> + (0.7071067812+0j)|11>
+    Before measurement: Bell state =  (0.7071067812+0j)|00> + (0.7071067812+0j)|11>
 
     After measurement:  {'00': 1.0, '01': 0.0, '10': 0.0, '11': 0.0}
     After measurement:  {'00': 0.0, '01': 0.0, '10': 0.0, '11': 1.0}

--- a/docs/source/intro_to_qc.ipynb
+++ b/docs/source/intro_to_qc.ipynb
@@ -816,7 +816,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Before measurement: H|0> =  [ 0.70710678+0.j  0.00000000+0.j  0.00000000+0.j  0.70710678+0.j]\n",
+      "Before measurement: Bell state =  [ 0.70710678+0.j  0.00000000+0.j  0.00000000+0.j  0.70710678+0.j]\n",
       "After measurement:  {'11': 1.0, '10': 0.0, '00': 0.0, '01': 0.0}\n",
       "After measurement:  {'11': 0.0, '10': 0.0, '00': 1.0, '01': 0.0}\n",
       "After measurement:  {'11': 0.0, '10': 0.0, '00': 1.0, '01': 0.0}\n",
@@ -831,7 +831,7 @@
     "\n",
     "# this program prepares something called a Bell state (a special kind of \"entangled state\")\n",
     "bell_program = Program(H(0), CNOT(0, 1))\n",
-    "print \"Before measurement: H|0> = \", quantum_simulator.wavefunction(bell_program)\n",
+    "print \"Before measurement: Bell state = \", quantum_simulator.wavefunction(bell_program)\n",
     "bell_program.measure(0, classical_reg)\n",
     "for x in range(5):\n",
     "    print \"After measurement: \", quantum_simulator.probabilities(bell_program)"


### PR DESCRIPTION
I think it may be confusing to someone who is just getting into quantum computing.

Basically, H|0> isn't Bell state of two-qubit system.