### PR TITLE
Disable tests on Python 2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, docs, flake8
+envlist = py35, py36, docs, flake8
 
 [testenv]
 recreate=


### PR DESCRIPTION
PyQuil 1.9 will not officially support Python 2. We can no longer spare the extra dev time to support this legacy platform. No purposefully breaking changes will be introduced in version 1.9 but we will not go out of our way to test for incompatibilities.

PyQuil 2 will use python-3-only features and will no longer support python2 even unofficially. 