### PR TITLE
ISA: return proper type for edge/qubit dead identifier

### DIFF
--- a/pyquil/device.py
+++ b/pyquil/device.py
@@ -110,12 +110,12 @@ class ISA(_ISA):
         return ISA(
             qubits=sorted([Qubit(id=int(qid),
                                  type=q.get("type", DEFAULT_QUBIT_TYPE),
-                                 dead=q.get("dead", False))
+                                 dead=True if q.get("dead") else False)
                            for qid, q in d["1Q"].items()],
                           key=lambda qubit: qubit.id),
             edges=sorted([Edge(targets=[int(q) for q in eid.split('-')],
                                type=e.get("type", DEFAULT_EDGE_TYPE),
-                               dead=e.get("dead", False))
+                               dead=True if e.get("dead") else False)
                           for eid, e in d["2Q"].items()],
                          key=lambda edge: edge.targets),
         )


### PR DESCRIPTION
The `dead` identifier of an qubit/edge is not a Pythonic True, rahter string 'true':

```
>>> for qubit in device.isa.qubits:
...     print(qubit)
... 
Qubit(id=0, type='Xhalves', dead=False)
Qubit(id=1, type='Xhalves', dead=False)
Qubit(id=2, type='Xhalves', dead=False)
Qubit(id=3, type='Xhalves', dead='true')
Qubit(id=4, type='Xhalves', dead=False)
...
```

This PR fixes it to be actually set to True:

```
>>> for qubit in device.isa.qubits:
...     print(qubit)
... 
Qubit(id=0, type='Xhalves', dead=False)
Qubit(id=1, type='Xhalves', dead=False)
Qubit(id=2, type='Xhalves', dead=False)
Qubit(id=3, type='Xhalves', dead=True)
Qubit(id=4, type='Xhalves', dead=False)
...
```