### PR TITLE
Bugfix/304 dagger params

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -429,6 +429,8 @@ class Program(object):
 
         for gate in self._defined_gates:
             if inv_dict is None or gate.name not in inv_dict:
+                if gate.parameters:
+                    raise TypeError("Cannot auto define daggered version of parameterized gates")
                 daggered.defgate(gate.name + suffix, gate.matrix.T.conj())
 
         for gate in reversed(self._instructions):
@@ -448,7 +450,7 @@ class Program(object):
                 else:
                     gate_inv_name = inv_dict[gate.name]
 
-                daggered.inst(tuple([gate_inv_name] + gate.qubits))
+                daggered.inst(Gate(gate_inv_name, gate.params, gate.qubits))
 
         return daggered
 

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -265,6 +265,21 @@ def test_dagger():
     p = Program().defgate("G", G).inst(("G", 0))
     assert p.dagger(inv_dict=inv_dict).out() == 'J 0\n'
 
+    # defined parameterized gates cannot auto generate daggered version https://github.com/rigetticomputing/pyquil/issues/304
+    theta = Parameter('theta')
+    gparam_matrix = np.array([[quil_cos(theta / 2), -1j * quil_sin(theta / 2)],
+                   [-1j * quil_sin(theta / 2), quil_cos(theta / 2)]])
+    g_param_def = DefGate('GPARAM', gparam_matrix, [theta])
+    p = Program(g_param_def)
+    with pytest.raises(TypeError):
+        p.dagger()
+
+    # defined parameterized gates should passback parameters https://github.com/rigetticomputing/pyquil/issues/304
+
+    GPARAM = g_param_def.get_constructor()
+    p = Program(GPARAM(pi)(1, 2))
+    assert p.dagger().out() == 'GPARAM-INV(pi) 1 2\n'
+
 
 def test_construction_syntax():
     p = Program().inst(X(0), Y(1), Z(0)).measure(0, 1)

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -268,14 +268,13 @@ def test_dagger():
     # defined parameterized gates cannot auto generate daggered version https://github.com/rigetticomputing/pyquil/issues/304
     theta = Parameter('theta')
     gparam_matrix = np.array([[quil_cos(theta / 2), -1j * quil_sin(theta / 2)],
-                   [-1j * quil_sin(theta / 2), quil_cos(theta / 2)]])
+                             [-1j * quil_sin(theta / 2), quil_cos(theta / 2)]])
     g_param_def = DefGate('GPARAM', gparam_matrix, [theta])
     p = Program(g_param_def)
     with pytest.raises(TypeError):
         p.dagger()
 
     # defined parameterized gates should passback parameters https://github.com/rigetticomputing/pyquil/issues/304
-
     GPARAM = g_param_def.get_constructor()
     p = Program(GPARAM(pi)(1, 2))
     assert p.dagger().out() == 'GPARAM-INV(pi) 1 2\n'


### PR DESCRIPTION
Fixes #304
- Raise a type error when attempting to auto-generate daggered version of parameterized gates
- Output gate parameters for daggered versions of user-defined gates
- Add tests for dagger on user-defined parameterized gates