### PR TITLE
Adding support for generating RB sequences and clifford conjugation

### DIFF
--- a/examples/benchmarking_example.ipynb
+++ b/examples/benchmarking_example.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The below is an example of how to run some benchmarking routines from within Pyquil. The first is conjugating a Pauli by a Clifford element, and the second is constructing randomized benchmarking sequences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyquil.quil import Program\n",
+    "from pyquil.api import CompilerConnection\n",
+    "from pyquil.gates import CNOT, X,Z, Y, PHASE, H\n",
+    "from pyquil.paulis import PauliTerm\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc = CompilerConnection()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clifford = Program().inst(X(1000))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pauli = PauliTerm(\"Y\", 1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(-1+0j)*Y1000\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cc.apply_clifford_to_pauli(clifford, pauli))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clifford = Program().inst(X(0), CNOT(0, 1), Y(1), Z(0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pauli = PauliTerm(\"Y\", 0) * PauliTerm(\"Z\", 1, 1.j)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1j*Y0*X1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cc.apply_clifford_to_pauli(clifford, pauli))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gateset_1q = [PHASE(np.pi/2, 0), H(0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "progs = cc.generate_rb_sequence(100, 1, gateset_1q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "H 0\n",
+      "PHASE(pi/2) 0\n",
+      "H 0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(progs[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(progs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gateset_2q = [PHASE(np.pi/2, 0), H(0), CNOT(0, 1), H(1), PHASE(np.pi/2, 1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PHASE(pi/2) 0\n",
+      "CNOT 0 1\n",
+      "H 1\n",
+      "CNOT 0 1\n",
+      "H 0\n",
+      "PHASE(pi/2) 0\n",
+      "H 1\n",
+      "CNOT 0 1\n",
+      "H 0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "progs_2q = cc.generate_rb_sequence(100, 2, gateset_2q)\n",
+    "print(progs_2q[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -324,6 +324,34 @@ class PauliTerm(object):
         pterm.coefficient = complex(coefficient)
         return pterm
 
+    def pauli_string(self, qubits=None):
+        """
+        Return a string representation of this PauliTerm mod its phase, as a concatenation of the string representation
+        of the
+        >>> p = PauliTerm("X", 0) * PauliTerm("Y", 1, 1.j)
+        >>> p.pauli_string()
+        "XY"
+        >>> p.pauli_string([0])
+        "X"
+        >>> p.pauli_string([0, 2])
+        "XI"
+
+        :param list qubits: The list of qubits to represent, given as ints. If None, defaults to all qubits in this
+         PauliTerm.
+        :return: The string representation of this PauliTerm, modulo its phase.
+        :rtype: String
+        """
+        qubit_term_mapping = dict(self.operations_as_set())
+        if qubits is None:
+            qubits = [qubit for qubit, _ in qubit_term_mapping.items()]
+        ps = ""
+        for qubit in qubits:
+            try:
+                ps += qubit_term_mapping[qubit]
+            except KeyError:
+                ps += "I"
+        return ps
+
 
 # For convenience, a shorthand for several operators.
 def ID():

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -26,7 +26,8 @@ from pyquil.api import QVMConnection, QPUConnection, CompilerConnection
 from pyquil.api._base_connection import validate_noise_probabilities, validate_run_items
 from pyquil.api.qpu import append_measures_to_program
 from pyquil.quil import Program
-from pyquil.gates import CNOT, H, MEASURE
+from pyquil.paulis import PauliTerm
+from pyquil.gates import CNOT, H, MEASURE, PHASE
 from pyquil.device import ISA
 
 BELL_STATE = Program(H(0), CNOT(0, 1))
@@ -374,3 +375,38 @@ def test_job_compile():
 
         result = async_compiler.compile(BELL_STATE)
         assert result == BELL_STATE
+
+
+def test_compiler_without_isa():
+    with pytest.raises(ValueError):
+        CompilerConnection().compile(Program())
+
+
+def test_rb_sequence():
+    num_qubits = 1
+    gateset = [PHASE(np.pi, 0), H(0)]
+    depth = 2
+    # Random sequences corresponding to sampling H(0) and PHASE(0, 0), then inverting them.
+    sampled_sequence = [[1, 1], [0, 0]]
+
+    def mock_queued_response(_, __):
+        return json.dumps(sampled_sequence)
+
+    with requests_mock.Mocker() as m:
+        m.post('https://api.rigetti.com/rb', text=mock_queued_response)
+        result = async_compiler.generate_rb_sequence(depth, num_qubits, gateset)
+        assert result == [Program().inst([gateset[i] for i in clifford]) for clifford in sampled_sequence]
+
+
+def test_apply_clifford_to_pauli():
+    clifford = Program().inst("H 0")
+    pauli = PauliTerm("X", 0)
+    # The first element should be the power of i that is the phase, and the second should be the pauli from conjugation.
+    response = [0, "Z"]
+
+    def mock_queued_response(_, __):
+        return json.dumps(response)
+    with requests_mock.Mocker() as m:
+        m.post('https://api.rigetti.com/apply-clifford', text=mock_queued_response)
+        result = async_compiler.apply_clifford_to_pauli(clifford, pauli)
+        assert result == PauliTerm("Z", 0)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -635,3 +635,12 @@ def test_simplify_warning():
 
     assert tsum == 2 * sZ(0) * sZ(1)
     assert str(e[0].message).startswith('The term Z1Z0 will be combined with Z0Z1')
+
+
+def test_pauli_string():
+    p = PauliTerm("X", 1) * PauliTerm("Z", 5)
+    assert p.pauli_string([1, 5]) == "XZ"
+    assert p.pauli_string([1]) == "X"
+    assert p.pauli_string([5]) == "Z"
+    assert p.pauli_string([5, 6]) == "ZI"
+    assert p.pauli_string([0, 1]) == "IX"


### PR DESCRIPTION
@mpharrigan This PR is meant to provide functionality for conjugating `PauliTerms` by Clifford circuits, and generating randomized benchmarking sequences. Both of these target different endpoints than the compiler. 