### PR TITLE
program.measure_all() defaults to measuring all qubits.

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -254,7 +254,8 @@ class Program(object):
     def measure_all(self, *qubit_reg_pairs):
         """
         Measures many qubits into their specified classical bits, in the order
-        they were entered.
+        they were entered. If no qubit/register pairs are provided, measure all qubits present in
+        the program into classical addresses of the same index.
 
         :param Tuple qubit_reg_pairs: Tuples of qubit indices paired with classical bits.
         :return: The Quil Program with the appropriate measure instructions appended, e.g.
@@ -267,8 +268,11 @@ class Program(object):
 
         :rtype: Program
         """
-        for qubit_index, classical_reg in qubit_reg_pairs:
-            self.inst(MEASURE(qubit_index, classical_reg))
+        if qubit_reg_pairs == ():
+            [self.inst(MEASURE(qubit_index, qubit_index)) for qubit_index in self.get_qubits()]
+        else:
+            for qubit_index, classical_reg in qubit_reg_pairs:
+                self.inst(MEASURE(qubit_index, classical_reg))
         return self
 
     def while_do(self, classical_reg, q_program):

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -221,6 +221,15 @@ def test_measure_all():
                       'MEASURE 1 [1]\n' \
                       'MEASURE 2 [3]\n'
 
+    p = Program([H(idx) for idx in range(4)])
+    p.measure_all()
+    for idx in range(4):
+        assert p[idx + 4] == MEASURE(idx, idx)
+
+    p = Program()
+    p.measure_all()
+    assert p.out() == ''
+
 
 def test_dagger():
     # these gates are their own inverses


### PR DESCRIPTION
Resolves #223. If no qubit/register pairs are provided to `program.measure_all()`, all qubits are measured.