### PR TITLE
Default classical_addresses in qvm./qpu.run method

### DIFF
--- a/pyquil/api/qpu.py
+++ b/pyquil/api/qpu.py
@@ -154,7 +154,7 @@ with the former, the device.
         self.ping_time = ping_time
         self.status_time = status_time
 
-    def run(self, quil_program, classical_addresses=[], trials=1, needs_compilation=True, isa=None):
+    def run(self, quil_program, classical_addresses=None, trials=1, needs_compilation=True, isa=None):
         """
         Run a pyQuil program on the QPU and return the values stored in the classical registers
         designated by the classical_addresses parameter. The program is repeated according to
@@ -175,18 +175,18 @@ with the former, the device.
         :return: A list of a list of classical registers (each register contains a bit)
         :rtype: list
         """
-        if classical_addresses == []:
+        if not classical_addresses:
             classical_addresses = get_classical_addresses_from_program(quil_program)
 
         job = self.wait_for_job(self.run_async(quil_program, classical_addresses, trials, needs_compilation, isa))
         return job.result()
 
-    def run_async(self, quil_program, classical_addresses=[], trials=1, needs_compilation=True, isa=None):
+    def run_async(self, quil_program, classical_addresses=None, trials=1, needs_compilation=True, isa=None):
         """
         Similar to run except that it returns a job id and doesn't wait for the program to
         be executed. See https://go.rigetti.com/connections for reasons to use this method.
         """
-        if classical_addresses == []:
+        if not classical_addresses:
             classical_addresses = get_classical_addresses_from_program(quil_program)
 
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation=needs_compilation, isa=isa)

--- a/pyquil/api/qpu.py
+++ b/pyquil/api/qpu.py
@@ -20,7 +20,7 @@ from six import integer_types
 from pyquil.api.job import Job
 from pyquil.device import Device
 from pyquil.gates import MEASURE
-from pyquil.quil import Program
+from pyquil.quil import Program, get_classical_addresses_from_program
 from ._base_connection import (validate_run_items, TYPE_MULTISHOT, TYPE_MULTISHOT_MEASURE,
                                get_job_id, get_session, wait_for_job, post_json, get_json,
                                parse_error)
@@ -154,7 +154,7 @@ with the former, the device.
         self.ping_time = ping_time
         self.status_time = status_time
 
-    def run(self, quil_program, classical_addresses, trials=1, needs_compilation=True, isa=None):
+    def run(self, quil_program, classical_addresses=[], trials=1, needs_compilation=True, isa=None):
         """
         Run a pyQuil program on the QPU and return the values stored in the classical registers
         designated by the classical_addresses parameter. The program is repeated according to
@@ -175,14 +175,20 @@ with the former, the device.
         :return: A list of a list of classical registers (each register contains a bit)
         :rtype: list
         """
+        if classical_addresses == []:
+            classical_addresses = get_classical_addresses_from_program(quil_program)
+
         job = self.wait_for_job(self.run_async(quil_program, classical_addresses, trials, needs_compilation, isa))
         return job.result()
 
-    def run_async(self, quil_program, classical_addresses, trials=1, needs_compilation=True, isa=None):
+    def run_async(self, quil_program, classical_addresses=[], trials=1, needs_compilation=True, isa=None):
         """
         Similar to run except that it returns a job id and doesn't wait for the program to
         be executed. See https://go.rigetti.com/connections for reasons to use this method.
         """
+        if classical_addresses == []:
+            classical_addresses = get_classical_addresses_from_program(quil_program)
+
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation=needs_compilation, isa=isa)
         response = post_json(self.session, self.async_endpoint + "/job", self._wrap_program(payload))
         return get_job_id(response)

--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -106,7 +106,7 @@ programs run on this QVM.
     def ping(self):
         raise DeprecationWarning("ping() function is deprecated")
 
-    def run(self, quil_program, classical_addresses=[], trials=1, needs_compilation=False, isa=None):
+    def run(self, quil_program, classical_addresses=None, trials=1, needs_compilation=False, isa=None):
         """
         Run a Quil program multiple times, accumulating the values deposited in
         a list of classical addresses.
@@ -120,7 +120,7 @@ programs run on this QVM.
                  in `classical_addresses`.
         :rtype: list
         """
-        if classical_addresses == []:
+        if not classical_addresses:
             classical_addresses = get_classical_addresses_from_program(quil_program)
 
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation, isa)
@@ -135,12 +135,12 @@ programs run on this QVM.
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
             return response.json()
 
-    def run_async(self, quil_program, classical_addresses=[], trials=1, needs_compilation=False, isa=None):
+    def run_async(self, quil_program, classical_addresses=None, trials=1, needs_compilation=False, isa=None):
         """
         Similar to run except that it returns a job id and doesn't wait for the program to be executed.
         See https://go.rigetti.com/connections for reasons to use this method.
         """
-        if classical_addresses == []:
+        if not classical_addresses:
             classical_addresses = get_classical_addresses_from_program(quil_program)
 
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation, isa)

--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -19,7 +19,7 @@ from six import integer_types
 
 from pyquil.api.job import Job
 from pyquil.api.compiler import CompilerConnection
-from pyquil.quil import Program
+from pyquil.quil import Program, get_classical_addresses_from_program
 from pyquil.wavefunction import Wavefunction
 from pyquil.noise import apply_noise_model
 from ._base_connection import validate_noise_probabilities, validate_run_items, TYPE_MULTISHOT, \
@@ -106,7 +106,7 @@ programs run on this QVM.
     def ping(self):
         raise DeprecationWarning("ping() function is deprecated")
 
-    def run(self, quil_program, classical_addresses, trials=1, needs_compilation=False, isa=None):
+    def run(self, quil_program, classical_addresses=[], trials=1, needs_compilation=False, isa=None):
         """
         Run a Quil program multiple times, accumulating the values deposited in
         a list of classical addresses.
@@ -120,6 +120,9 @@ programs run on this QVM.
                  in `classical_addresses`.
         :rtype: list
         """
+        if classical_addresses == []:
+            classical_addresses = get_classical_addresses_from_program(quil_program)
+
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation, isa)
         if self.use_queue or needs_compilation:
             if needs_compilation and not self.use_queue:
@@ -132,11 +135,14 @@ programs run on this QVM.
             response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
             return response.json()
 
-    def run_async(self, quil_program, classical_addresses, trials=1, needs_compilation=False, isa=None):
+    def run_async(self, quil_program, classical_addresses=[], trials=1, needs_compilation=False, isa=None):
         """
         Similar to run except that it returns a job id and doesn't wait for the program to be executed.
         See https://go.rigetti.com/connections for reasons to use this method.
         """
+        if classical_addresses == []:
+            classical_addresses = get_classical_addresses_from_program(quil_program)
+
         payload = self._run_payload(quil_program, classical_addresses, trials, needs_compilation, isa)
         response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})
         return get_job_id(response)

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -619,3 +619,17 @@ def shift_quantum_gates(program, shift_offset):
             for qubit in instruct.qubits:
                 qubit.index += shift_offset
     return shifted_program
+
+
+def get_classical_addresses_from_program(program):
+    """
+    Returns a sorted list of classical addresses found in the MEASURE instructions in the program.
+
+    :param Program program: The program from which to get the classical addresses.
+    :return: A list of integer classical addresses.
+    :rtype: list
+    """
+    # Required to use the `classical_reg.address` int attribute.
+    # See https://github.com/rigetticomputing/pyquil/issues/388.
+    return sorted(set([instr.classical_reg.address for instr in program
+                       if hasattr(instr, 'classical_reg')]))

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -632,4 +632,4 @@ def get_classical_addresses_from_program(program):
     # Required to use the `classical_reg.address` int attribute.
     # See https://github.com/rigetticomputing/pyquil/issues/388.
     return sorted(set([instr.classical_reg.address for instr in program
-                       if hasattr(instr, 'classical_reg')]))
+                       if isinstance(instr, Measurement)]))

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -46,17 +46,21 @@ def test_sync_run():
             "type": "multishot",
             "addresses": [0, 1],
             "trials": 2,
-            "compiled-quil": "H 0\nCNOT 0 1\n"
+            "compiled-quil": "H 0\nCNOT 0 1\nMEASURE 0 [0]\nMEASURE 1 [1]\n"
         }
         return '[[0,0],[1,1]]'
 
     with requests_mock.Mocker() as m:
         m.post('https://api.rigetti.com/qvm', text=mock_response)
-        assert qvm.run(BELL_STATE, [0, 1], trials=2) == [[0, 0], [1, 1]]
+        assert qvm.run(BELL_STATE_MEASURE, [0, 1], trials=2) == [[0, 0], [1, 1]]
 
         # Test range as well
         m.post('https://api.rigetti.com/qvm', text=mock_response)
-        assert qvm.run(BELL_STATE, range(2), trials=2) == [[0, 0], [1, 1]]
+        assert qvm.run(BELL_STATE_MEASURE, range(2), trials=2) == [[0, 0], [1, 1]]
+
+        # Test no classical addresses
+        m.post('https://api.rigetti.com/qvm', text=mock_response)
+        assert qvm.run(BELL_STATE_MEASURE, trials=2) == [[0, 0], [1, 1]]
 
 
 def test_sync_run_and_measure():

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -24,7 +24,8 @@ from pyquil.gates import I, X, Y, Z, H, T, S, RX, RY, RZ, CNOT, CCNOT, PHASE, CP
     CPHASE10, CPHASE, SWAP, CSWAP, ISWAP, PSWAP, MEASURE, HALT, WAIT, NOP, RESET, \
     TRUE, FALSE, NOT, AND, OR, MOVE, EXCHANGE
 from pyquil.parameters import Parameter, quil_sin, quil_cos
-from pyquil.quil import Program, merge_programs, shift_quantum_gates
+from pyquil.quil import Program, merge_programs, shift_quantum_gates, \
+    get_classical_addresses_from_program
 from pyquil.quilbase import DefGate, Gate, Addr, Qubit, JumpWhen
 
 
@@ -645,3 +646,11 @@ def test_defgate_integer_input():
     dg = DefGate("TEST", np.array([[1, 0],
                                    [0, 1]]))
     assert dg.out() == "DEFGATE TEST:\n    1, 0\n    0, 1\n"
+
+
+def test_get_classical_addresses_from_program():
+    p = Program([H(i) for i in range(4)])
+    assert get_classical_addresses_from_program(p) == []
+
+    p += [MEASURE(i, i) for i in [0, 3, 1]]
+    assert get_classical_addresses_from_program(p) == [0, 1, 3]


### PR DESCRIPTION
Resolves #137. If the `.run` method for either the QVM or the QPU is not supplied a `classical_addresses` argument, a `get_classical_addresses_from_program` function will infer the classical addresses from the `MEASURE` instructions in the program.