### PR TITLE
Excepting DeviceRetuning & DeviceOffline Errors

### DIFF
--- a/pyquil/api/qpu.py
+++ b/pyquil/api/qpu.py
@@ -197,7 +197,7 @@ with the former, the device.
             try:
                 response = post_json(self.session, self.async_endpoint + "/job", self._wrap_program(payload))
             except errors.DeviceRetuningError:
-                print("QPU is retuning. Trying to reconnect...")
+                print("QPU is retuning. Will try to reconnect in 10 seconds...")
                 time.sleep(10)
 
         return get_job_id(response)


### PR DESCRIPTION
When running e.g. a large QAOA job on the QPU the connection gets killed when the device gets retuned (which yields either a DeviceRetuning or DeviceOffline error) which means all the work until this point goes down the drain. This PR resolves the problem by excepting these two types of error.