### PR TITLE
doc improvements for expectation, and an added warning

### DIFF
--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -320,14 +320,19 @@ programs run on this QVM.
             generally be different*.
 
         :param Program prep_prog: Quil program for state preparation.
-        :param list operator_programs: A list of PauliTerms. Default is Identity operator.
+        :param list operator_programs: A list of Programs, each specifying an operator whose expectation to compute.
+         Default is a list containing only the empty Program.
         :param bool needs_compilation: If True, preprocesses the job with the compiler.
         :param ISA isa: If set, compiles to this target ISA.
         :returns: Expectation value of the operators.
         :rtype: float
         """
+        if isinstance(operator_programs, Program):
+            warnings.warn("You have provided a Program rather than a list of Programs. The results from expectation "
+                          "will be line-wise expectation values of the operator_programs.", SyntaxWarning)
         if needs_compilation:
-            raise TypeError("Expectation QVM programs do not support compilation preprocessing.  Make a separate CompilerConnection job first.")
+            raise TypeError("Expectation QVM programs do not support compilation preprocessing."
+                            "  Make a separate CompilerConnection job first.")
         if self.use_queue:
             payload = self._expectation_payload(prep_prog, operator_programs)
             response = post_json(self.session, self.async_endpoint + "/job", {"machine": "QVM", "program": payload})


### PR DESCRIPTION
@mpharrigan I've updated the docs in qvm.py to try to help set users `expectation`s. 

I'm not sure standard practice for warnings, but I just spent some time trying to debug why I was getting the wrong answer, when I was giving it a program, and it was happily iterating over it and shipping off the line-by-line subprograms.

e.g. 
`qvm.expectation(Program("X 0\nY 1"))`
When what I really wanted was
`qvm.expectation([Program("X 0\nY 1"))`

Of course you can also tell from the length of the returned list, but I think warning the user is a good idea.