### PR TITLE
propagate Forest errors through Job.compiled_quil()

### DIFF
--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -173,6 +173,11 @@ class Job(object):
         prog = self._raw.get("program", {}).get("compiled-quil", None)
         if prog is not None:
             return parse_program(prog)
+        else:
+            # if we failed too early to even get a "compiled-quil" field,
+            # then alert the user to that problem instead
+            if self._raw['status'] == 'ERROR':
+                return self.result()
 
     def topological_swaps(self):
         """


### PR DESCRIPTION
Closes #400.

It's not clear to me how extensive this error forwarding should be among the other accessors on a Job object. I think it's fine to add this error handling in just this one place, but I invite advice.