### PR TITLE
Fix document string for the return type of exponential_map

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -753,7 +753,7 @@ def exponential_map(term):
 
     :param PauliTerm term: Tests is a PauliTerm is the identity operator
     :returns: Program
-    :rtype: Program
+    :rtype: Function
     """
     if not np.isclose(np.imag(term.coefficient), 0.0):
         raise TypeError("PauliTerm coefficient must be real")


### PR DESCRIPTION
Changing document string to reflect what the exponential_map procedure is doing in an attempt to close this issue: https://github.com/rigetticomputing/pyquil/issues/322.