### PR TITLE
Prettier str() representation of QubitPlaceholder and programs containing them

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -55,7 +55,7 @@ class QubitPlaceholder(QuilAtom):
         raise RuntimeError("Qubit {} has not been assigned an index".format(self))
 
     def __str__(self):
-        return repr(self)
+        return "q{}".format(id(self))
 
     def __repr__(self):
         return "<QubitPlaceholder {}>".format(id(self))

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -67,12 +67,8 @@ def _format_qubits_str(qubits):
     return " ".join([_format_qubit_str(qubit) for qubit in qubits])
 
 
-def _format_qubit_out(qubit):
-    return qubit.out()
-
-
 def _format_qubits_out(qubits):
-    return " ".join([_format_qubit_out(qubit) for qubit in qubits])
+    return " ".join([qubit.out() for qubit in qubits])
 
 
 def _format_params(params):
@@ -141,9 +137,9 @@ class Measurement(AbstractInstruction):
 
     def out(self):
         if self.classical_reg:
-            return "MEASURE {} {}".format(_format_qubit_out(self.qubit), self.classical_reg.out())
+            return "MEASURE {} {}".format(self.qubit.out(), self.classical_reg.out())
         else:
-            return "MEASURE {}".format(_format_qubit_out(self.qubit))
+            return "MEASURE {}".format(self.qubit.out())
 
     def __str__(self):
         if self.classical_reg:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -57,6 +57,28 @@ def _extract_qubit_index(qubit, index=True):
     return qubit.index
 
 
+def _format_qubit_str(qubit):
+    if isinstance(qubit, QubitPlaceholder):
+        return "{%s}" % str(qubit)
+    return str(qubit)
+
+
+def _format_qubits_str(qubits):
+    return " ".join([_format_qubit_str(qubit) for qubit in qubits])
+
+
+def _format_qubit_out(qubit):
+    return qubit.out()
+
+
+def _format_qubits_out(qubits):
+    return " ".join([_format_qubit_out(qubit) for qubit in qubits])
+
+
+def _format_params(params):
+    return "(" + ",".join(format_parameter(param) for param in params) + ")"
+
+
 class Gate(AbstractInstruction):
     """
     This is the pyQuil object for a quantum gate instruction.
@@ -86,31 +108,21 @@ class Gate(AbstractInstruction):
         return {_extract_qubit_index(q, indices) for q in self.qubits}
 
     def out(self):
-        def format_params(params):
-            return "(" + ",".join(map(format_parameter, params)) + ")"
-
-        def format_qubits(qubits):
-            return " ".join([qubit.out() for qubit in qubits])
-
         if self.params:
-            return "{}{} {}".format(self.name, format_params(self.params), format_qubits(self.qubits))
+            return "{}{} {}".format(self.name, _format_params(self.params),
+                                    _format_qubits_out(self.qubits))
         else:
-            return "{} {}".format(self.name, format_qubits(self.qubits))
+            return "{} {}".format(self.name, _format_qubits_out(self.qubits))
 
     def __repr__(self):
         return "<Gate " + str(self) + ">"
 
     def __str__(self):
-        def format_params(params):
-            return "(" + ",".join(map(format_parameter, params)) + ")"
-
-        def format_qubits(qubits):
-            return " ".join([str(qubit) for qubit in qubits])
-
         if self.params:
-            return "{}{} {}".format(self.name, format_params(self.params), format_qubits(self.qubits))
+            return "{}{} {}".format(self.name, _format_params(self.params),
+                                    _format_qubits_str(self.qubits))
         else:
-            return "{} {}".format(self.name, format_qubits(self.qubits))
+            return "{} {}".format(self.name, _format_qubits_str(self.qubits))
 
 
 class Measurement(AbstractInstruction):
@@ -129,9 +141,15 @@ class Measurement(AbstractInstruction):
 
     def out(self):
         if self.classical_reg:
-            return "MEASURE {} {}".format(self.qubit, self.classical_reg)
+            return "MEASURE {} {}".format(_format_qubit_out(self.qubit), self.classical_reg.out())
         else:
-            return "MEASURE {}".format(self.qubit)
+            return "MEASURE {}".format(_format_qubit_out(self.qubit))
+
+    def __str__(self):
+        if self.classical_reg:
+            return "MEASURE {} {}".format(_format_qubit_str(self.qubit), str(self.classical_reg))
+        else:
+            return "MEASURE {}".format(_format_qubit_str(self.qubit))
 
     def get_qubits(self, indices=True):
         return {_extract_qubit_index(self.qubit, indices)}

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -40,7 +40,7 @@ def test_simplify_terms():
     assert term.coefficient == -1.0
 
     term = PauliTerm('Z', q[0]) + PauliTerm('Z', q[0], 1.0)
-    assert str(term).startswith('(2+0j)*Z<QubitPlaceholder ')
+    assert str(term).startswith('(2+0j)*Zq')
 
 
 def test_get_qubits():
@@ -212,9 +212,9 @@ def test_ps_sub():
     assert str(b - 1.0) == "(1+0j)*I"
     assert str(1.0 - b) == "(-1+0j)*I"
     b = 1.0 - sX(q0)
-    assert re.match(r"\(1\+0j\)\*I \+ \(-1\+0j\)\*X<.+>", str(b))
+    assert re.match(r"\(1\+0j\)\*I \+ \(-1\+0j\)\*Xq\d+", str(b))
     b = sX(q0) - 1.0
-    assert re.match(r"\(1\+0j\)\*X<.+> \+ \(-1\+0j\)\*I", str(b))
+    assert re.match(r"\(1\+0j\)\*Xq\d+ \+ \(-1\+0j\)\*I", str(b))
 
 
 def test_exponentiate_1():

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -441,7 +441,7 @@ def test_alloc():
 
     with pytest.raises(RuntimeError) as e:
         _ = p.out()
-    assert e.match(r'Qubit <QubitPlaceholder \d+> has not been assigned an index')
+    assert e.match(r'Qubit q\d+ has not been assigned an index')
 
 
 def test_alloc_2():
@@ -766,10 +766,10 @@ def test_out_vs_str():
 
     with pytest.raises(RuntimeError) as e:
         pq.out()
-    assert e.match(r'Qubit <.*> has not been assigned an index')
+    assert e.match(r'Qubit q\d+ has not been assigned an index')
 
     string_version = str(pq)
-    should_be_re = (r'X <.*>\nCNOT <.*> <.*>\nMEASURE <.*> \[5\]\n')
+    should_be_re = (r'X \{q\d+\}\nCNOT \{q\d+\} \{q\d+\}\nMEASURE \{q\d+\} \[5\]\n')
     assert re.fullmatch(should_be_re, string_version, flags=re.MULTILINE)
 
 


### PR DESCRIPTION
```
RX(-pi) {q4632261800}
RZ(-pi/2) {q4632261800}
RX(-pi/2) {q4632261800}
RY(-pi/2) {q4632261800}
RX(-pi) {q4632261800}
RY(pi/2) {q4632261800}
RX(-pi/2) {q4632261800}
RY(pi/2) {q4632261800}
RY(-pi/2) {q4632261800}
RZ(-pi/2) {q4632261800}
RX(-pi/2) {q4632261800}
RZ(-pi/2) {q4632261800}
RX(-pi) {q4632261800}
RZ(pi/2) {q4632261800}
RX(-pi/2) {q4632261800}
RZ(pi/2) {q4632261800}
RX(pi/2) {q4632261800}
RX(-pi/2) {q4632261800}
RZ(pi/2) {q4632261800}
MEASURE {q4632261800} [0]
```