### PR TITLE
Randomized benchmarking does not always compose to the identity

### DIFF
--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -441,14 +441,16 @@ def test_rb_sequence():
 
     with requests_mock.Mocker() as m:
         m.post('https://api.rigetti.com/rb', text=mock_queued_response)
-        result = async_compiler.generate_rb_sequence(depth, gateset)
-        assert result == [Program().inst([gateset[i] for i in clifford]) for clifford in sampled_sequence]
+        result = list(reversed(async_compiler.generate_rb_sequence(depth, gateset)))
+        assert result == [Program().inst([gateset[i] for i in clifford])
+                          for clifford in sampled_sequence]
 
 
 def test_apply_clifford_to_pauli():
     clifford = Program().inst("H 0")
     pauli = PauliTerm("X", 0)
-    # The first element should be the power of i that is the phase, and the second should be the pauli from conjugation.
+    # The first element should be the power of i that is the phase,
+    #  and the second should be the pauli from conjugation.
     response = [0, "Z"]
 
     def mock_queued_response(_, __):


### PR DESCRIPTION
The new randomized benchmarking routine does not always compose to the identity. In addition, it would be useful to have more/better documentation.

Both of these are addressed in this PR.

In addition, I've removed the qubits argument from RB. It seems redundant, given that the generating gateset should act on the same number of qubits that you want to benchmark. 

@mpharrigan - I know API changes are bad, but given that this feature is in its infancy, I think it's better to rethink the signature now, rather than later.

This is also something that likely would have been caught by tests, but we don't have a framework set up yet to test the QVM or Compiler from pyQuil, as we've discussed before.