### PR TITLE
Clearing up the instructions for the first program in the basics tutorial

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -46,7 +46,7 @@ program on the Quantum Virtual Machine, or QVM:
     from pyquil.api import QVMConnection
     qvm = QVMConnection()
 
-    qvm.run(p)
+    print(qvm.run(p, [0]))
 
 Congratulations! You just ran a program on the QVM. The returned value should be:
 


### PR DESCRIPTION
Addressing this issue: https://github.com/rigetticomputing/pyquil/issues/435

`print` is added because the tutorial says ```The returned value should be: [[1]]```. It's more clear if the value is printed.