### PR TITLE
fix forest link in pyquil-config-setup instructions

### DIFF
--- a/pyquil/setup/pyquil_config_setup.py
+++ b/pyquil/setup/pyquil_config_setup.py
@@ -22,7 +22,7 @@ from pyquil.api._config import PyquilConfig
 def main():
     print("Welcome to PyQuil!")
     print("Enter the required information below for Forest connections.")
-    print("If you haven't signed up yet you will need to do so first at https://forest.rigetti.com")
+    print("If you haven't signed up yet you will need to do so first at http://forest.rigetti.com")
 
     key = input("Forest API Key: ")
     user = input("User ID: ")


### PR DESCRIPTION
Fixes #442 

