### PR TITLE
Fixing cliffords again

### DIFF
--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -259,7 +259,7 @@ class CompilerConnection(object):
         programs = []
         for clifford in response:
             clifford_program = Program()
-            for index in clifford:
+            for index in reversed(clifford):
                 clifford_program.inst(gateset[index])
             programs.append(clifford_program)
         # The programs are returned in "textbook style" right-to-left order. To compose them into

--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -259,6 +259,8 @@ class CompilerConnection(object):
         programs = []
         for clifford in response:
             clifford_program = Program()
+            # Like below, we reversed the order because the API currently hands back the Clifford
+            # decomposition right-to-left.
             for index in reversed(clifford):
                 clifford_program.inst(gateset[index])
             programs.append(clifford_program)


### PR DESCRIPTION
The order of the returned cliffords was recently reversed (and I verified this gave the identity, I thought, on a handful of circuits.) It appears that the Clifford decompositions also need to be reversed. I verified that this worked on a handful of circuits returned, but I encourage reviewers to verify themselves so this doesn't happen again.