### PR TITLE
Magic Quil Decorator

### DIFF
--- a/pyquil/magic.py
+++ b/pyquil/magic.py
@@ -1,0 +1,203 @@
+import ast
+import functools
+import inspect
+from copy import deepcopy
+
+from contextvars import ContextVar
+
+from pyquil import gates
+from pyquil.quil import Program
+from pyquil.quilatom import Addr
+
+_program_context = ContextVar('program')
+
+
+def program_context() -> Program:
+    """
+    Returns the current program in context. Will only work from inside calls to @magicquil.
+    If called from outside @magicquil will throw a ValueError
+
+    :return: program if one exists
+    """
+    return _program_context.get()
+
+
+def I(qubit) -> None:
+    program_context().inst(gates.I(qubit))
+
+
+def X(qubit) -> None:
+    program_context().inst(gates.X(qubit))
+
+
+def H(qubit) -> None:
+    program_context().inst(gates.H(qubit))
+
+
+def CNOT(qubit1, qubit2) -> None:
+    program_context().inst(gates.CNOT(qubit1, qubit2))
+
+
+def MEASURE(qubit) -> Addr:
+    program_context().inst(gates.MEASURE(qubit, qubit))
+    return Addr(qubit)
+
+
+def _if_statement(test, if_function, else_function) -> None:
+    """
+    Evaluate an if statement within a @magicquil block.
+
+    If the test value is a Quil Addr then unwind it into quil code equivalent to an if then statement using jumps. Both
+    sides of the if statement need to be evaluated and placed into separate Programs, which is why we create new
+    program contexts for their evaluation.
+
+    If the test value is not a Quil Addr then fall back to what Python would normally do with an if statement.
+
+    Params are:
+        if <test>:
+            <if_function>
+        else:
+            <else_function>
+
+    NB: This function must be named exactly _if_statement and be in scope for the ast transformer
+    """
+    if isinstance(test, Addr):
+        token = _program_context.set(Program())
+        if_function()
+        if_program = _program_context.get()
+        _program_context.reset(token)
+
+        if else_function:
+            token = _program_context.set(Program())
+            else_function()
+            else_program = _program_context.get()
+            _program_context.reset(token)
+        else:
+            else_program = None
+
+        program = _program_context.get()
+        program.if_then(test.address, if_program, else_program)
+    else:
+        if test:
+            if_function()
+        elif else_function:
+            else_function()
+
+
+_EMPTY_ARGUMENTS = ast.arguments(args=[], vararg=None, kwonlyargs=[], kwarg=None, defaults=[], kw_defaults=[])
+
+
+class _IfTransformer(ast.NodeTransformer):
+    """
+    Transformer that unwraps the if and else branches into separate inner functions and then wraps them in a call to
+    _if_statement. For example:
+
+        if 1 + 1 == 2:
+            print('math works')
+        else:
+            print('something is broken')
+
+    would be transformed into:
+
+        def _if_branch():
+            print('math works')
+        def _else_branch():
+            print('something is broken')
+        _if_statement(1 + 1 == 2, _if_branch, _else_branch)
+    """
+    def visit_If(self, node):
+        # Must recursively visit the body of both the if and else bodies to handle any nested if and else statements
+        # This also conveniently handles elif since those are just treated as a nested if/else within the else branch
+        # See: https://greentreesnakes.readthedocs.io/en/latest/nodes.html#If
+        node = self.generic_visit(node)
+
+        if_function = ast.FunctionDef(name='_if_branch', body=node.body, decorator_list=[], args=_EMPTY_ARGUMENTS)
+        else_function = ast.FunctionDef(name='_else_branch', body=node.orelse, decorator_list=[], args=_EMPTY_ARGUMENTS)
+
+        if_function_name = ast.Name(id='_if_branch', ctx=ast.Load())
+        else_function_name = ast.Name(id='_else_branch', ctx=ast.Load())
+
+        if node.orelse:
+            return [
+                if_function,
+                else_function,
+                ast.Expr(ast.Call(
+                    func=ast.Name(id='_if_statement', ctx=ast.Load()),
+                    args=[node.test, if_function_name, else_function_name],
+                    keywords=[]))
+            ]
+        else:
+            return [
+                if_function,
+                ast.Expr(ast.Call(
+                    func=ast.Name(id='_if_statement', ctx=ast.Load()),
+                    args=[node.test, if_function_name, ast.NameConstant(None)],
+                    keywords=[]))
+            ]
+
+
+def _rewrite_function(f):
+    """
+    Rewrite a function so that any if/else branches are intercepted and their behavior can be overridden. This is
+    accomplished using 3 steps:
+
+    1. Get the source of the function and then rewrite the AST using _IfTransformer
+    2. Do some small fixups to the tree to make sure
+        a) the function doesn't have the same name, and
+        b) the decorator isn't called recursively on the transformed function as well
+    3. Bring the variables from the call site back into scope
+
+    :param f: Function to rewrite
+    :return: Rewritten function
+    """
+    source = inspect.getsource(f)
+    tree = ast.parse(source)
+    _IfTransformer().visit(tree)
+
+    ast.fix_missing_locations(tree)
+    tree.body[0].name = f.__name__ + '_patched'
+    tree.body[0].decorator_list = []
+
+    compiled = compile(tree, filename='<ast>', mode='exec')
+    # The first f_back here gets to the body of magicquil() and the second f_back gets to the user's call site which
+    # is what we want. If we didn't add these manually to the globals it wouldn't be possible to call other @magicquil
+    # functions from within a @magicquil function.
+    prev_globals = inspect.currentframe().f_back.f_back.f_globals
+    # For reasons I don't quite understand it's critical to add locals() here otherwise the function will disappear and
+    # we won't be able to return it below
+    exec(compiled, {**prev_globals, **globals()}, locals())
+    return locals()[f.__name__ + '_patched']
+
+
+def magicquil(f):
+    """
+    Decorator to enable a more convenient syntax for writing quil programs. With this decorator there is no need to
+    keep track of a Program object and regular Python if/else branches can be used for classical control flow.
+
+    Example usage:
+
+        @magicquil
+        def fast_reset(q1):
+            reg1 = MEASURE(q1)
+            if reg1:
+                X(q1)
+            else:
+                I(q1)
+
+        my_program = fast_reset(0)  # this will be a Program object
+    """
+    rewritten_function = _rewrite_function(f)
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if _program_context.get(None) is not None:
+            rewritten_function(*args, **kwargs)
+            program = _program_context.get()
+        else:
+            token = _program_context.set(Program())
+            rewritten_function(*args, **kwargs)
+            program = _program_context.get()
+            _program_context.reset(token)
+        return program
+
+    return wrapper

--- a/pyquil/tests/test_magic.py
+++ b/pyquil/tests/test_magic.py
@@ -1,0 +1,72 @@
+from pyquil.magic import *
+
+
+@magicquil
+def bell_state(q1, q2):
+    H(q1)
+    CNOT(q1, q2)
+
+
+def test_bell_state():
+    assert bell_state(0, 1) == Program('H 0\nCNOT 0 1')
+
+
+@magicquil
+def fast_reset(q1):
+    reg1 = MEASURE(q1)
+    if reg1:
+        X(q1)
+    else:
+        I(q1)
+
+
+def test_fast_reset():
+    assert fast_reset(0) == Program('MEASURE 0 [0]').if_then(0, Program('X 0'), Program('I 0'))
+
+
+@magicquil
+def no_else(q1):
+    reg1 = MEASURE(q1)
+    if reg1:
+        X(q1)
+
+
+def test_no_else():
+    assert no_else(0) == Program('MEASURE 0 [0]').if_then(0, Program('X 0'))
+
+
+@magicquil
+def with_elif(q1, q2):
+    reg1 = MEASURE(q1)
+    reg2 = MEASURE(q2)
+    if reg1:
+        X(q1)
+    elif reg2:
+        X(q2)
+
+
+def test_with_elif():
+    assert with_elif(0, 1) == Program('MEASURE 0 [0]\nMEASURE 1 [1]')\
+        .if_then(0, Program('X 0'), Program().if_then(1, Program('X 1')))
+
+
+@magicquil
+def calls_another(q1, q2, q3):
+    bell_state(q1, q2)
+    CNOT(q2, q3)
+
+
+def test_calls_another():
+    assert calls_another(0, 1, 2) == Program('H 0\nCNOT 0 1\nCNOT 1 2')
+
+
+@magicquil
+def still_works_with_bools():
+    if 1 + 1 == 2:
+        H(0)
+    else:
+        H(1)
+
+
+def test_stills_works_with_bools():
+    assert still_works_with_bools() == Program('H 0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-antlr4-python2-runtime==4.7; python_version < '3'
-antlr4-python3-runtime==4.7; python_version >= '3'
+antlr4-python3-runtime==4.7
 certifi==2017.7.27.1
 chardet==3.0.4
 codeclimate-test-reporter==0.2.3
+contextvars==2.2
 coverage==4.4.1
 cycler==0.10.0
 flake8==3.4.1

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,13 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     license="LICENSE",
     install_requires=[
-        'requests >= 2.4.2',
+        'contextvars == 2.2',
         'numpy >= 1.10',
         'matplotlib >= 1.5',
+        'requests >= 2.4.2',
         'typing >= 3.6',
         'urllib3 >= 1.21.1',
-        "antlr4-python2-runtime>=4.7; python_version < '3'",
-        "antlr4-python3-runtime>=4.7; python_version >= '3'",
+        "antlr4-python3-runtime>=4.7",
     ],
     setup_requires=['pytest-runner'],
     tests_require=[


### PR DESCRIPTION
Allows you to write this:

```python
@magicquil
def fast_reset(q1):
    reg1 = MEASURE(q1)
    if reg1:
        X(q1)
    else:
        I(q1)

my_program = fast_reset(0)  # this will be a Program object
```

Another example from @mpharrigan:
```python
@magicquil
def qaoa(reward: PauliSum, driver: PauliSum, p_steps: int):
    for q in driver.get_qubits():
        H(q)

    betas = np.linspace(1, 0, p_steps)
    gammas = np.linspace(0, 1, p_steps)

    for beta, gamma in zip(betas, gammas):
        for term in reward:
            EXP(term, gamma)
        for term in driver:
            EXP(term, beta)
```

Read through the comments to explain how this is done through a combination of AST manipulation, context variables, and frame hacking.

### Known issues:
- Inner functions don't work. There is an easy fix for this (just unindent the source lines before sending it to the parser) but I was too lazy.
- This only supports a few gates right now since they need to be manually copied over.

### Potential future work:
- Add more functionality to the classical register that's returned by MEASURE so that you could do things like `if classical_reg1 + classical_reg2 > 0:`. This can be accomplished by overriding the `__eq__`, `__gt__`, etc. methods.
- Add more gates and also make the gate API a bit nicer by allowing you to pass in lists of qubits.
- Add AddrPlaceholders to PyQuil so that addresses can be assigned on demand.