### PR TITLE
Fix quantum_die example

### DIFF
--- a/examples/quantum_die.py
+++ b/examples/quantum_die.py
@@ -66,7 +66,7 @@ def roll_die(n):
     while True:
         results = qvm.run(die, addresses, BATCH_SIZE)
         for r in results:
-            x = process_result(r)
+            x = process_result(r) + 1
             if 0 < x <= n:
                 return x
 


### PR DESCRIPTION
When `n = 2^m`, quantum_die example returns an incorrect value. For example, in the case of `n = 8`, process_result(r) returns `0-7` because qubits length is 3. Therefore, this example returns `1-7`, never returns `8`. We have to add `1` to the process_result(r) value to get the correct value.