### PR TITLE
Improve error probability computation in  noise.damping_after_dephasing

### DIFF
--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -289,8 +289,10 @@ def damping_after_dephasing(T1, T2, gate_time):
     :param float gate_time: The gate duration.
     :return: A list of Kraus operators.
     """
-    damping = damping_kraus_map(p=gate_time / float(T1)) if T1 != INFINITY else [np.eye(2)]
-    dephasing = dephasing_kraus_map(p=gate_time / float(T2)) if T2 != INFINITY else [np.eye(2)]
+    damping = damping_kraus_map(p=1 - np.exp(-float(gate_time) / float(T1))) \
+        if T1 != INFINITY else [np.eye(2)]
+    dephasing = dephasing_kraus_map(p=.5 * (1 - np.exp(-2 * gate_time / float(T2)))) \
+        if T2 != INFINITY else [np.eye(2)]
     return combine_kraus_maps(damping, dephasing)
 
 

--- a/pyquil/tests/test_noise.py
+++ b/pyquil/tests/test_noise.py
@@ -52,8 +52,8 @@ def test_combine_kraus_maps():
 
 
 def test_damping_after_dephasing():
-    damping = damping_kraus_map()
-    dephasing = dephasing_kraus_map()
+    damping = damping_kraus_map(p=1 - np.exp(-.1))
+    dephasing = dephasing_kraus_map(p=.5 * (1 - np.exp(-.2)))
     ks_ref = combine_kraus_maps(damping, dephasing)
 
     ks_actual = damping_after_dephasing(10, 10, 1)


### PR DESCRIPTION
As discussed with @mpharrigan and motivated by @ncrubin this corrects the conversion from "gate_time/coherence_time" to the actual error probability for a single gate.