### PR TITLE
Fixed issue #464: nice API for job running time and time in queue

### DIFF
--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -121,16 +121,30 @@ class Job(object):
     def running_time(self):
         """
         For how long was the job running?
-        :rtype: Optional[str]
+        :return: Running time, seconds
+        :rtype: Optional[float]
         """
-        return self._raw['running_time']
+        if not self.is_done():
+            raise ValueError("Cannot get running time for a program that isn't completed.")
+        try:
+            running_time = float(self._raw['running_time'].split()[0])
+        except (ValueError, KeyError, IndexError):
+            raise UnknownApiError(str(self._raw))
+        return running_time
 
     def time_in_queue(self):
         """
         For how long was the job in the Forest queue?
-        :rtype: Optional[str]
+        :return: Time in queue, seconds
+        :rtype: Optional[float]
         """
-        return self._raw['time_in_queue']
+        if not self.is_done():
+            raise ValueError("Cannot get time in queue for a program that isn't completed.")
+        try:
+            time_in_queue = float(self._raw['time_in_queue'].split()[0])
+        except (ValueError, KeyError, IndexError):
+            raise UnknownApiError(str(self._raw))
+        return time_in_queue
 
     def get(self):
         warnings.warn("""

--- a/pyquil/api/job.py
+++ b/pyquil/api/job.py
@@ -118,6 +118,20 @@ class Job(object):
         if self.is_queued():
             return ROUND_TRIP_JOB_TIME * self.position_in_queue()
 
+    def running_time(self):
+        """
+        For how long was the job running?
+        :rtype: Optional[str]
+        """
+        return self._raw['running_time']
+
+    def time_in_queue(self):
+        """
+        For how long was the job in the Forest queue?
+        :rtype: Optional[str]
+        """
+        return self._raw['time_in_queue']
+
     def get(self):
         warnings.warn("""
         Running get() on a Job is now a no-op.


### PR DESCRIPTION
Added two convenience functions `job.running_time()` and `job.time_in_queue()`