### PR TITLE
Docs: reveal parser

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -105,6 +105,23 @@ following are all valid programs:
     X 0
     Y 0
 
+PyQuil can also produce a Program object by interpreting raw Quil text, as in
+the following example:
+
+.. code:: python
+
+    print(Program("X 0\nH 1\nCNOT 0 1"))
+
+.. parsed-literal::
+
+    X 0
+    H 1
+    CNOT 0 1
+
+The ``pyquil.parser`` submodule provides a front-end to other similar parser
+functionality.
+
+
 Fixing a Mistaken Instruction
 -----------------------------
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -41,6 +41,14 @@ pyquil.parametric
     :undoc-members:
     :show-inheritance:
 
+pyquil.parser
+-------------
+
+.. automodule:: pyquil.parser
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 pyquil.paulis
 -------------
 


### PR DESCRIPTION
This branch adds `pyquil.parser` autodoc information to the pyQuil docs, as well as a short demonstration of a `Program` constructor feature that uses the parser.