### PR TITLE
Fix return type docstring on QVM wavefunction API

### DIFF
--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -263,9 +263,7 @@ programs run on this QVM.
         :param list|range classical_addresses: An optional list of classical addresses.
         :param needs_compilation: If True, preprocesses the job with the compiler.
         :param isa: If set, compiles to this target ISA.
-        :return: A tuple whose first element is a Wavefunction object,
-                 and whose second element is the list of classical bits corresponding
-                 to the classical addresses.
+        :return: A Wavefunction object representing the state of the QVM.
         :rtype: Wavefunction
         """
         if classical_addresses is None:


### PR DESCRIPTION
The docs for `qvm.wavefunction` appear out of date. They say:
```
        :return: A tuple whose first element is a Wavefunction object,
                 and whose second element is the list of classical bits corresponding
                 to the classical addresses.
```
while
```
pq = Program(H(0), H(1)).measure_all()
print(qvm.wavefunction(pq))
>>> (1+0j)|00>
```

This PR fixes this. @mpharrigan 