### PR TITLE
feature/endpoints-envvars

### DIFF
--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -27,6 +27,7 @@ from ._base_connection import TYPE_MULTISHOT, get_job_id, get_session, \
 ASYNC_ENDPOINT = os.getenv('FOREST_ASYNC_ENDPOINT', 'https://job.rigetti.com/beta')
 SYNC_ENDPOINT = os.getenv('FOREST_SYNC_ENDPOINT', 'https://api.rigetti.com')
 
+
 class CompilerConnection(object):
     """
     Represents a connection to the Quil compiler.

--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -13,6 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+import os
 
 from pyquil.api.job import Job
 from pyquil.device import Device, ISA, Specs
@@ -23,13 +24,16 @@ from ._base_connection import TYPE_MULTISHOT, get_job_id, get_session, \
     wait_for_job, post_json, get_json
 
 
+ASYNC_ENDPOINT = os.getenv('FOREST_ASYNC_ENDPOINT', 'https://job.rigetti.com/beta')
+SYNC_ENDPOINT = os.getenv('FOREST_SYNC_ENDPOINT', 'https://api.rigetti.com')
+
 class CompilerConnection(object):
     """
     Represents a connection to the Quil compiler.
     """
 
-    def __init__(self, device=None, sync_endpoint='https://api.rigetti.com',
-                 async_endpoint='https://job.rigetti.com/beta', api_key=None,
+    def __init__(self, device=None, sync_endpoint=SYNC_ENDPOINT,
+                 async_endpoint=ASYNC_ENDPOINT, api_key=None,
                  user_id=None, use_queue=False, ping_time=0.1, status_time=2,
                  isa_source=None, specs_source=None):
         """

--- a/pyquil/api/qpu.py
+++ b/pyquil/api/qpu.py
@@ -13,6 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+import os
 import warnings
 import time
 
@@ -28,7 +29,10 @@ from ._base_connection import (validate_run_items, TYPE_MULTISHOT, TYPE_MULTISHO
                                parse_error)
 
 
-def get_devices(async_endpoint='https://job.rigetti.com/beta', api_key=None, user_id=None,
+ASYNC_ENDPOINT = os.getenv('FOREST_ASYNC_ENDPOINT', 'https://job.rigetti.com/beta')
+
+
+def get_devices(async_endpoint=ASYNC_ENDPOINT, api_key=None, user_id=None,
                 as_dict=False):
     """
     Get a list of currently available devices. The arguments for this method are the same as those for QPUConnection.
@@ -78,7 +82,7 @@ class QPUConnection(object):
     Represents a connection to the QPU (Quantum Processing Unit)
     """
 
-    def __init__(self, device=None, async_endpoint='https://job.rigetti.com/beta', api_key=None,
+    def __init__(self, device=None, async_endpoint=ASYNC_ENDPOINT, api_key=None,
                  user_id=None, ping_time=0.1, status_time=2, device_name=None):
         """
         Constructor for QPUConnection. Sets up necessary security and picks a device to run on.

--- a/pyquil/api/qvm.py
+++ b/pyquil/api/qvm.py
@@ -13,6 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+import os
 import warnings
 
 from six import integer_types
@@ -28,13 +29,17 @@ from ._base_connection import validate_noise_probabilities, validate_run_items, 
     post_json, get_json
 
 
+ASYNC_ENDPOINT = os.getenv('FOREST_ASYNC_ENDPOINT', 'https://job.rigetti.com/beta')
+SYNC_ENDPOINT = os.getenv('FOREST_SYNC_ENDPOINT', 'https://api.rigetti.com')
+
+
 class QVMConnection(object):
     """
     Represents a connection to the QVM.
     """
 
-    def __init__(self, device=None, sync_endpoint='https://api.rigetti.com',
-                 async_endpoint='https://job.rigetti.com/beta', api_key=None, user_id=None,
+    def __init__(self, device=None, sync_endpoint=SYNC_ENDPOINT,
+                 async_endpoint=ASYNC_ENDPOINT, api_key=None, user_id=None,
                  use_queue=False, ping_time=0.1, status_time=2, gate_noise=None,
                  measurement_noise=None, random_seed=None):
         """


### PR DESCRIPTION
Using os.getenv to get forest sync and async endpoints, or default back to the original values.