### PR TITLE
Initial faculties for testing against a real qvm

### DIFF
--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from pyquil.api import QVMConnection, CompilerConnection
+from pyquil.api.errors import UnknownApiError
 from pyquil.device import Device, ISA
 from pyquil.gates import I
 from pyquil.quil import Program
@@ -71,7 +72,7 @@ def qvm():
         qvm = QVMConnection(random_seed=52)
         qvm.run(Program(I(0)), [0])
         return qvm
-    except RequestException as e:
+    except (RequestException, UnknownApiError) as e:
         return pytest.skip("This test requires QVM connection: {}".format(e))
 
 
@@ -81,5 +82,5 @@ def compiler():
         compiler = CompilerConnection()
         compiler.compile(Program(I(0)), isa=ISA.from_dict(isa_dict))
         return compiler
-    except RequestException as e:
+    except (RequestException, UnknownApiError) as e:
         return pytest.skip("This test requires compiler connection: {}".format(e))

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
-
-from pyquil.device import Device
+from pyquil.api import QVMConnection, CompilerConnection
+from pyquil.device import Device, ISA
+from pyquil.gates import I
+from pyquil.quil import Program
+from requests import RequestException
 
 
 @pytest.fixture
@@ -60,3 +63,23 @@ def device_raw(isa_dict, noise_model_dict):
 @pytest.fixture
 def test_device(device_raw):
     return Device('test_device', device_raw)
+
+
+@pytest.fixture(scope='session')
+def qvm():
+    try:
+        qvm = QVMConnection(random_seed=52)
+        qvm.run(Program(I(0)), [0])
+        return qvm
+    except RequestException as e:
+        return pytest.skip("This test requires QVM connection: {}".format(e))
+
+
+@pytest.fixture(scope='session')
+def compiler():
+    try:
+        compiler = CompilerConnection()
+        compiler.compile(Program(I(0)), isa=ISA.from_dict(isa_dict))
+        return compiler
+    except RequestException as e:
+        return pytest.skip("This test requires compiler connection: {}".format(e))

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -26,7 +26,7 @@ def isa_dict():
             "1-2": {
                 "type": "ISWAP"
             },
-            "2-0": {
+            "0-2": {
                 "type": "CPHASE"
             },
             "0-3": {
@@ -79,8 +79,8 @@ def qvm():
 @pytest.fixture(scope='session')
 def compiler():
     try:
-        compiler = CompilerConnection()
-        compiler.compile(Program(I(0)), isa=ISA.from_dict(isa_dict))
+        compiler = CompilerConnection(isa_source=ISA.from_dict(isa_dict()))
+        compiler.compile(Program(I(0)))
         return compiler
     except (RequestException, UnknownApiError) as e:
         return pytest.skip("This test requires compiler connection: {}".format(e))

--- a/pyquil/tests/test_device.py
+++ b/pyquil/tests/test_device.py
@@ -94,9 +94,9 @@ def test_isa(isa_dict):
         ],
         edges=[
             Edge(targets=[0, 1], type='CZ', dead=False),
+            Edge(targets=[0, 2], type='CPHASE', dead=False),
             Edge(targets=[0, 3], type='CZ', dead=True),
             Edge(targets=[1, 2], type='ISWAP', dead=False),
-            Edge(targets=[2, 0], type='CPHASE', dead=False),
         ])
     assert isa == ISA.from_dict(isa.to_dict())
 


### PR DESCRIPTION
New test fixtures for getting a qvm. I'll update semaphore with an API key. If the connections cannot be made, the test will be skipped.

The only test that uses the new functionality in this PR is the new `test_sync_run` (old version moved to `test_sync_run_mock`). The idea is to get it working and then go through piecewise to add tests against real qvms/compilers as appropriate 

cc #424 