### PR TITLE
fix defcircuit pyquil parsing

### DIFF
--- a/pyquil/_parser/PyQuilListener.py
+++ b/pyquil/_parser/PyQuilListener.py
@@ -114,7 +114,24 @@ class PyQuilListener(QuilListener):
 
     def exitDefCircuit(self, ctx):
         # type: (QuilParser.DefCircuitContext) -> None
-        self.result.append(RawInstr(ctx.getText()))
+        def flatten_tree(ctx_tree):
+            nodes = []
+
+            def inner(tree):
+                num_children = tree.getChildCount()
+                if num_children == 0:
+                    nodes.append(tree)
+                else:
+                    for i in range(num_children):
+                        inner(tree.getChild(i))
+
+            inner(ctx_tree)
+            return nodes
+
+        token_list = flatten_tree(ctx)
+        raw_string = ' '.join([xx.getText() for xx in token_list])
+
+        self.result.append(RawInstr(raw_string))
 
     def exitGate(self, ctx):
         # type: (QuilParser.GateContext) -> None


### PR DESCRIPTION
There was a bug in DEFCIRCUIT parsing where whitespace was getting lost. It looks like this on the current master:
```
DEFCIRCUIT BELL Qm Qn:
    H Qm
    CNOT Qm Qn
```
would parse to
```
DEFCIRCUITBELLQmQn:
    HQm
    CNOTQmQn
```
@tarballs-are-good and I identified that this was due to how the parser was building up the `RawInstr` from the lex'd tokens. This PR implements a fix from @tarballs-are-good.

Testing this fix is awkward in that the solution actually adds some different whitespace from the original raw string and so the raw strings aren't exactly equal. 

The underlying complexity here is that some tokens need spaces like `DEFCIRCUIT BELL Qm Qn` before them while other (like `:`) do not. In order to not make this blow out of proportion and just to fix it so that DEFCIRCUIT now works, this PR is submitted without taking on the underlying issue.