### PR TITLE
Add import statements for all the gates and for get_devices

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -302,7 +302,7 @@ The above sum can be constructed as follows:
 
     # Pauli term takes an operator "X", "Y", "Z", or "I"; a qubit to act on, and
     # an optional coefficient.
-    a = 0.5 * ID
+    a = 0.5 * ID()
     b = -0.75 * sX(0) * sY(1) * sZ(3)
     c = (5-2j) * sZ(1) * sX(2)
 

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -298,7 +298,6 @@ The above sum can be constructed as follows:
 
 .. code:: python
 
-    from pyquil.paulis import ID, sX, sY, sZ
 
     # Pauli term takes an operator "X", "Y", "Z", or "I"; a qubit to act on, and
     # an optional coefficient.

--- a/pyquil/__init__.py
+++ b/pyquil/__init__.py
@@ -4,3 +4,4 @@ from pyquil.quil import Program, Pragma
 from pyquil.api import QVMConnection, QPUConnection, CompilerConnection, get_devices
 from pyquil.parameters import Parameter, quil_sin, quil_cos, quil_sqrt, quil_exp, quil_cis
 from pyquil.quilbase import DefGate
+from pyquil.paulis import ID, sX, sY, sZ

--- a/pyquil/__init__.py
+++ b/pyquil/__init__.py
@@ -2,3 +2,5 @@ __version__ = "2.0.0.dev0"
 
 from pyquil.quil import Program
 from pyquil.api import QVMConnection, QPUConnection
+from pyquil.gates import *
+from pyquil.api import get_devices

--- a/pyquil/__init__.py
+++ b/pyquil/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "2.0.0.dev0"
 
-from pyquil.quil import Program
-from pyquil.api import QVMConnection, QPUConnection
-from pyquil.gates import *
-from pyquil.api import get_devices
+from pyquil.quil import Program, Pragma
+from pyquil.api import QVMConnection, QPUConnection, CompilerConnection, get_devices
+from pyquil.parameters import Parameter, quil_sin, quil_cos, quil_sqrt, quil_exp, quil_cis
+from pyquil.quilbase import DefGate


### PR DESCRIPTION
This pull request addresses https://github.com/rigetticomputing/pyquil/issues/302.
```
from pyquil import *

qvm = QVMConnection()
p = Program(H(0), CNOT(0, 1))

wf = qvm.wavefunction(p)
print(wf)


for device in get_devices():
    if device.is_online():
        print('Device {} is online'.format(device.name))
```
Can now execute.

How do we change the docs based on this change?  `intro.rst` has a couple of sentences where it explains

```
from pyqul.quil import Program
from pyquil.gates import I
from pyquil.api import QVMConnection
```
And the rest of the docs import specific gates. I think this is a good way to document a program because the user is stating which gates will be used. On the other hand, there is more typing involved. I never import specific gates. I always do `from pyquil.gates import *` because it's easier than stating the gates explicitly. 

What other imports would be useful to move to the top-level?