### PR TITLE
Rename the relevant forest server route and response keys to 'lattice…

### DIFF
--- a/pyquil/api/_devices.py
+++ b/pyquil/api/_devices.py
@@ -76,5 +76,5 @@ def _get_raw_lattice_data(lattice_name: str = None):
     session = get_session()
     config = PyquilConfig()
 
-    res = get_json(session, f"{config.forest_url}/plaquettes/{lattice_name}")
-    return res["plaquette"]
+    res = get_json(session, f"{config.forest_url}/lattices/{lattice_name}")
+    return res["lattice"]


### PR DESCRIPTION
Completes the rename to "lattice" everywhere