### PR TITLE
Improve QPU readout result unpacking

### DIFF
--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -96,7 +96,8 @@ def _collect_classical_memory_write_locations(program: Program) -> List[Optional
                     _log.warning(f"Overwriting the measured result in register "
                                  f"{instr.classical_reg} from qubit {ro_sources[offset]} "
                                  f"to qubit {q}")
-                # we track
+                # we track how often each qubit is measured (per shot) and into which register it is
+                # measured in its n-th measurement.
                 ro_sources[offset] = (q, measures_by_qubit[q])
             measures_by_qubit[q] += 1
     if ro_size:

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -83,8 +83,7 @@ class QPU(QAM):
         only do measurements where there is a 1-to-1 mapping between qubits and classical
         addresses.
 
-        :return: A numpy array of classified (0/1) measurement results of
-            shape (trials, size of "ro")
+        :return: The QPU object itself.
         """
         super().run()
 
@@ -96,7 +95,10 @@ class QPU(QAM):
         results = self._get_buffers(job_id)
         ro_sources = self.binary.ro_sources
 
-        bitstrings = self._extract_bitstrings(ro_sources, results)
+        if results:
+            bitstrings = self._extract_bitstrings(ro_sources, results)
+        else:
+            bitstrings = None
 
         self.bitstrings = bitstrings
         self._last_results = results

--- a/pyquil/tests/test_qpu.py
+++ b/pyquil/tests/test_qpu.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from pyquil import Program
+from pyquil.api._compiler import _collect_classical_memory_write_locations
 from pyquil.api._config import PyquilConfig
 from pyquil.api import QuantumComputer, QPU, QPUCompiler
 from pyquil.device import NxDevice
@@ -30,3 +31,54 @@ def test_qpu_run():
         assert np.mean(bitstrings) > 0.8
     else:
         pytest.skip("QPU or compiler-server not available; skipping QPU run test.")
+
+
+def test_readout_demux():
+    p = Program("""DECLARE ro BIT[6]
+RESET
+RX(pi/2) 0
+RX(pi/2) 1
+RX(pi/2) 2
+RX(pi/2) 3
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2
+RX(pi/2) 0
+RX(pi/2) 1
+RX(pi/2) 2
+RX(pi/2) 3
+MEASURE 0 ro[2]
+MEASURE 1 ro[3]
+MEASURE 2 ro[4]
+MEASURE 3 ro[5]
+""")
+    ro_sources = _collect_classical_memory_write_locations(p)
+
+    assert ro_sources == [
+        (0, 0),
+        (1, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (3, 0)
+    ]
+
+    num_shots = 1000
+    buffers = {
+        # 0 measured, stored twice
+        "q0": np.random.randint(0, 1, size=(num_shots, 2)),
+        # 1 measured, stored twice
+        "q1": np.random.randint(0, 1, size=(num_shots, 2)),
+        # 2 measured twice, stored once
+        "q2": np.random.randint(0, 1, size=(num_shots, 2)),
+        # 3 measured once
+        "q3": np.random.randint(0, 1, size=num_shots),
+    }
+
+    bitstrings = QPU._extract_bitstrings(ro_sources, buffers=buffers)
+    assert np.allclose(bitstrings[:, 0], buffers["q0"][:, 0])
+    assert np.allclose(bitstrings[:, 1], buffers["q1"][:, 0])
+    assert np.allclose(bitstrings[:, 2], buffers["q0"][:, 1])
+    assert np.allclose(bitstrings[:, 3], buffers["q1"][:, 1])
+    assert np.allclose(bitstrings[:, 4], buffers["q2"][:, 1])
+    assert np.allclose(bitstrings[:, 5], buffers["q3"])

--- a/pyquil/tests/test_qpu.py
+++ b/pyquil/tests/test_qpu.py
@@ -66,13 +66,13 @@ MEASURE 3 ro[5]
     num_shots = 1000
     buffers = {
         # 0 measured, stored twice
-        "q0": np.random.randint(0, 1, size=(num_shots, 2)),
+        "q0": np.random.randint(0, 2, size=(num_shots, 2)),
         # 1 measured, stored twice
-        "q1": np.random.randint(0, 1, size=(num_shots, 2)),
+        "q1": np.random.randint(0, 2, size=(num_shots, 2)),
         # 2 measured twice, stored once
-        "q2": np.random.randint(0, 1, size=(num_shots, 2)),
+        "q2": np.random.randint(0, 2, size=(num_shots, 2)),
         # 3 measured once
-        "q3": np.random.randint(0, 1, size=num_shots),
+        "q3": np.random.randint(0, 2, size=num_shots),
     }
 
     bitstrings = QPU._extract_bitstrings(ro_sources, buffers=buffers)


### PR DESCRIPTION
* Make robust to unset readout locations ro_sources[idx] === None
* Allow for non-protoquil sequences with multiple measures on one qubit