### PR TITLE
change default compiler/qvm endpoints

### DIFF
--- a/pyquil/api/_config.py
+++ b/pyquil/api/_config.py
@@ -78,7 +78,7 @@ class PyquilConfig(object):
         "file": FOREST_CONFIG,
         "section": "Rigetti Forest",
         "name": "qvm_address",
-        "default": "http://localhost:5000"
+        "default": "http://127.0.0.1:5000"
     }
 
     COMPILER_URL = {
@@ -86,7 +86,7 @@ class PyquilConfig(object):
         "file": FOREST_CONFIG,
         "section": "Rigetti Forest",
         "name": "compiler_server_address",
-        "default": "http://localhost:6000"
+        "default": "http://127.0.0.1:6000"
     }
 
     def __init__(self):

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -83,13 +83,13 @@ def test_sync_run_mock():
         return '{"ro": [[0,0],[1,1]]}'
 
     with requests_mock.Mocker() as m:
-        m.post('http://localhost:5000/qvm', text=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', text=mock_response)
         assert mock_qvm.run(BELL_STATE_MEASURE,
                             [0, 1],
                             trials=2) == [[0, 0], [1, 1]]
 
         # Test no classical addresses
-        m.post('http://localhost:5000/qvm', text=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', text=mock_response)
         assert mock_qvm.run(BELL_STATE_MEASURE, trials=2) == [[0, 0], [1, 1]]
 
     with pytest.raises(ValueError):
@@ -123,7 +123,7 @@ def test_sync_run_and_measure_mock():
         return '[[0,0],[1,1]]'
 
     with requests_mock.Mocker() as m:
-        m.post('http://localhost:5000/qvm', text=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', text=mock_response)
         assert mock_qvm.run_and_measure(BELL_STATE, [0, 1], trials=2) == [[0, 0], [1, 1]]
 
     with pytest.raises(ValueError):
@@ -155,13 +155,13 @@ def test_sync_expectation_mock():
         return b'[0.0, 0.0, 1.0]'
 
     with requests_mock.Mocker() as m:
-        m.post('http://localhost:5000/qvm', content=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', content=mock_response)
         result = mock_qvm.expectation(BELL_STATE, [Program(Z(0)), Program(Z(1)), Program(Z(0), Z(1))])
         exp_expected = [0.0, 0.0, 1.0]
         np.testing.assert_allclose(exp_expected, result)
 
     with requests_mock.Mocker() as m:
-        m.post('http://localhost:5000/qvm', content=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', content=mock_response)
         z0 = PauliTerm("Z", 0)
         z1 = PauliTerm("Z", 1)
         z01 = z0 * z1
@@ -195,7 +195,7 @@ def test_sync_paulisum_expectation():
         return b'[1.0, 0.0, 0.0]'
 
     with requests_mock.Mocker() as m:
-        m.post('http://localhost:5000/qvm', content=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', content=mock_response)
         z0 = PauliTerm("Z", 0)
         z1 = PauliTerm("Z", 1)
         z01 = z0 * z1
@@ -224,7 +224,7 @@ def test_seeded_qvm(test_device):
     with patch.object(LocalQVMCompiler, "quil_to_native_quil") as m_compile,\
             patch('pyquil.api._qvm.apply_noise_model') as m_anm,\
             requests_mock.Mocker() as m:
-        m.post('http://localhost:5000/qvm', text=mock_response)
+        m.post('http://127.0.0.1:5000/qvm', text=mock_response)
         m_compile.side_effect = [BELL_STATE]
         m_anm.side_effect = [BELL_STATE]
 
@@ -294,7 +294,7 @@ def test_config_parsing():
 
 
 def test_get_qc_returns_local_qvm_compiler():
-    with patch.dict('os.environ', {"COMPILER_URL": "http://localhost:7000"}):
+    with patch.dict('os.environ', {"COMPILER_URL": "http://127.0.0.1:7000"}):
         qc = get_qc("9q-generic-qvm")
         assert isinstance(qc.compiler, LocalQVMCompiler)
 
@@ -344,7 +344,7 @@ def conjugate_pauli_by_clifford(payload: ConjugateByCliffordRequest) -> Conjugat
 
 @pytest.fixture
 def m_endpoints():
-    return "tcp://localhost:5555", "tcp://*:5555"
+    return "tcp://127.0.0.1:5555", "tcp://*:5555"
 
 
 def run_mock(_, endpoint):


### PR DESCRIPTION
Some users with network setups that do aggressive domain name rewriting have the name "localhost" mangled, but the localhost IP address seems to be safe in these scenarios.