### PR TITLE
Latest attempt at figuring out the best semantics for run_and_measure

### DIFF
--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -207,7 +207,6 @@ class QuantumComputer:
             program.inst(MEASURE(q, ro[i]))
         program.wrap_in_numshots_loop(trials)
         executable = self.compile(program)
-        print(executable)
         bitstring_array = self.run(executable=executable)
         bitstring_dict = {}
         for i, q in enumerate(self.qubits()):

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -15,7 +15,7 @@
 ##############################################################################
 import warnings
 from math import pi
-from typing import List
+from typing import List, Dict
 
 import networkx as nx
 import numpy as np
@@ -65,6 +65,15 @@ def _get_flipped_protoquil_program(program: Program) -> Program:
     return program
 
 
+def _validate_run_and_measure_program(program):
+    for instr in program.instructions:
+        if not isinstance(instr, Gate) and not isinstance(instr, Reset):
+            raise ValueError("run_and_measure programs must consist only of quantum gates.")
+
+    # TODO: more logic here?
+    return program
+
+
 class QuantumComputer:
     @_record_call
     def __init__(self, *, name: str, qam: QAM, device: AbstractDevice, compiler: AbstractCompiler,
@@ -93,6 +102,9 @@ class QuantumComputer:
         self.compiler = compiler
 
         self.symmetrize_readout = symmetrize_readout
+
+    def qubits(self):
+        return self.device.qubits()
 
     def qubit_topology(self):
         return self.device.qubit_topology()
@@ -161,9 +173,20 @@ class QuantumComputer:
         return results
 
     @_record_call
-    def run_and_measure(self, program: Program, trials: int):
+    def run_and_measure(self, program: Program, trials: int) -> Dict[int, np.ndarray]:
         """
         Run the provided state preparation program and measure all qubits.
+
+        This will measure all the qubits on this QuantumComputer, not just qubits
+        that are used in the program.
+
+        The returned data is a dictionary keyed by qubit index because qubits for a given
+        QuantumComputer may be non-contiguous and non-zero-indexed. To turn this dictionary
+        into a 2d numpy array of bitstrings, consider::
+
+            bitstrings = qc.run_and_measure(...)
+            bitstring_array = np.vstack(bitstrings[q] for q in sorted(qc.qubits())).T
+            bitstring_array.shape  # (trials, len(qc.qubits()))
 
         .. note::
 
@@ -174,18 +197,22 @@ class QuantumComputer:
 
         :param program: The state preparation program to run and then measure.
         :param trials: The number of times to run the program.
-        :return: A numpy array of shape (trials, n_device_qubits) that contains 0s and 1s
+        :return: A dictionary keyed by qubit index where the corresponding value is a 1D array of
+            measured bits.
         """
         program = program.copy()
-        for instr in program.instructions:
-            if not isinstance(instr, Gate) and not isinstance(instr, Reset):
-                raise ValueError("run_and_measure programs must consist only of quantum gates.")
-        ro = program.declare('ro', 'BIT', max(self.device.qubit_topology().nodes) + 1)
-        for q in sorted(self.device.qubit_topology().nodes):
-            program.inst(MEASURE(q, ro[q]))
+        program = _validate_run_and_measure_program(program)
+        ro = program.declare('ro', 'BIT', len(self.qubits()))
+        for i, q in enumerate(self.qubits()):
+            program.inst(MEASURE(q, ro[i]))
         program.wrap_in_numshots_loop(trials)
         executable = self.compile(program)
-        return self.run(executable=executable)
+        print(executable)
+        bitstring_array = self.run(executable=executable)
+        bitstring_dict = {}
+        for i, q in enumerate(self.qubits()):
+            bitstring_dict[q] = bitstring_array[:, i]
+        return bitstring_dict
 
     @_record_call
     def compile(self, program, to_native_gates=True, optimize=True):

--- a/pyquil/device.py
+++ b/pyquil/device.py
@@ -173,6 +173,7 @@ class Specs(_Specs):
     :ivar List[QubitSpecs] qubits_specs: The specs associated with individual qubits.
     :ivar List[EdgesSpecs] edges_specs: The specs associated with edges, or qubit-qubit pairs.
     """
+
     def f1QRBs(self):
         """
         Get a dictionary of single-qubit randomized benchmarking fidelities (normalized to unity)
@@ -376,6 +377,12 @@ def isa_to_graph(isa: ISA) -> nx.Graph:
 class AbstractDevice(ABC):
 
     @abstractmethod
+    def qubits(self):
+        """
+        A sorted list of qubits in the device topology.
+        """
+
+    @abstractmethod
     def qubit_topology(self) -> nx.Graph:
         """
         The connectivity of qubits in this device given as a NetworkX graph.
@@ -433,6 +440,9 @@ class Device(AbstractDevice):
         warnings.warn("Accessing the static ISA is deprecated. Use `get_isa`", DeprecationWarning)
         return self._isa
 
+    def qubits(self):
+        return sorted(q.id for q in self._isa.qubits if not q.dead)
+
     def qubit_topology(self) -> nx.Graph:
         """
         The connectivity of qubits in this device given as a NetworkX graph.
@@ -474,6 +484,9 @@ class NxDevice(AbstractDevice):
 
     def __init__(self, topology: nx.Graph) -> None:
         self.topology = topology
+
+    def qubits(self):
+        return sorted(self.topology.nodes)
 
     def qubit_topology(self):
         return self.topology

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -236,10 +236,23 @@ def test_qc(qvm, compiler):
     assert qc.qubit_topology().degree[4] == 4
 
     bs = qc.run_and_measure(Program(X(0)), trials=3)
-    assert bs.shape == (3, 9)
+    assert len(bs) == 9
+    for q, bits in bs.items():
+        assert bits.shape == (3,)
 
 
 def test_fully_connected_qvm_qc():
     qc = get_qc('qvm')
     for q1, q2 in itertools.permutations(range(34), r=2):
         assert (q1, q2) in qc.qubit_topology().edges
+
+
+def test_run_and_measure_concat(qvm, compiler):
+    qc = get_qc("9q-generic-qvm")
+    prog = Program(I(8))
+    trials = 11
+    # note to devs: this is included as an example in the run_and_measure docstrings
+    # so if you change it here ... change it there!
+    bitstrings = qc.run_and_measure(prog, trials)
+    bitstring_array = np.vstack(bitstrings[q] for q in sorted(qc.qubits())).T
+    assert bitstring_array.shape == (trials, len(qc.qubits()))


### PR DESCRIPTION
 - measure all qubits on a qc (not just the ones used in a program)
 - return as a dict instead of a 2d numpy array because of sparsely
   indexed qubits

cc @kylegulshen 