### PR TITLE
Update QAM.run()

### DIFF
--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -87,13 +87,13 @@ class QPU(QAM):
         """
         super().run()
 
-        request = QPURequest(program=self.binary.program,
+        request = QPURequest(program=self._executable.program,
                              patch_values=self._build_patch_values(),
                              id=str(uuid.uuid4()))
 
         job_id = self.shim.call('execute_qpu_request', request=request, user=self.user)
         results = self._get_buffers(job_id)
-        ro_sources = self.binary.ro_sources
+        ro_sources = self._executable.ro_sources
 
         if results:
             bitstrings = self._extract_bitstrings(ro_sources, results)
@@ -146,13 +146,13 @@ class QPU(QAM):
     def _build_patch_values(self) -> dict:
         patch_table = {}
 
-        for name, spec in self.binary.memory_descriptors.items():
+        for name, spec in self._executable.memory_descriptors.items():
             # NOTE: right now we fake reading out measurement values into classical memory
             if name == "ro":
                 continue
             patch_table[name] = [0] * spec.length
 
-        for k, v in self.variables_shim.items():
+        for k, v in self._variables_shim.items():
             # NOTE: right now we fake reading out measurement values into classical memory
             if k.name == "ro":
                 continue

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -101,28 +101,17 @@ class QuantumComputer:
         return self.device.get_isa(oneq_type=oneq_type, twoq_type=twoq_type)
 
     @_record_call
-    def run(self, executable: BinaryExecutableResponse, classical_addresses=None) -> np.ndarray:
+    def run(self, executable: BinaryExecutableResponse) -> np.ndarray:
         """
         Run a quil executable.
 
         :param executable: The program to run. You are responsible for compiling this first.
-        :param classical_addresses: The indices within regions of classical memory to report.
-            These don't necessarily correspond to qubit indices; rather they are the second
-            argument to any MEASURE instructions you've added to your program. If you don't
-            provide a specific collection, we will automatically report on all the locations
-            mentioned in your program.
-        :return: A numpy array of shape (trials, len(classical_addresses)) that contains 0s and 1s
+        :return: A numpy array of shape (trials, len(ro-register)) that contains 0s and 1s
         """
-        # shim old API to new `read_from_memory_region`
-        if classical_addresses is None:
-            offsets = True
-        else:
-            offsets = classical_addresses
-
         return self.qam.load(executable) \
             .run() \
             .wait() \
-            .read_from_memory_region(region_name="ro", offsets=offsets)
+            .read_from_memory_region(region_name="ro")
 
     @_record_call
     def run_symmetrized_readout(self, program, trials, classical_addresses):

--- a/pyquil/api/_qvm.py
+++ b/pyquil/api/_qvm.py
@@ -402,10 +402,10 @@ To read more about supplying noise to the QVM, see http://pyquil.readthedocs.io/
 
         super().run()
 
-        if isinstance(self.binary, PyQuilExecutableResponse):
-            quil_program = _extract_program_from_pyquil_executable_response(self.binary)
-        elif isinstance(self.binary, Program):
-            quil_program = self.binary
+        if isinstance(self._executable, PyQuilExecutableResponse):
+            quil_program = _extract_program_from_pyquil_executable_response(self._executable)
+        elif isinstance(self._executable, Program):
+            quil_program = self._executable
         else:
             raise TypeError("quil_binary argument must be a PyQuilExecutableResponse or a Program."
                             "This error is typically triggered by forgetting to pass (nativized)"
@@ -431,7 +431,7 @@ To read more about supplying noise to the QVM, see http://pyquil.readthedocs.io/
     def augment_program_with_memory_values(self, quil_program):
         p = Program()
 
-        for k, v in self.variables_shim.items():
+        for k, v in self._variables_shim.items():
             p += MOVE(MemoryReference(name=k.name, offset=k.index), v)
 
         p += quil_program


### PR DESCRIPTION
 - remove classical addresses. You just get everything now
 - all the shimmy things in QAM are now "private". Don't use these