### PR TITLE
Better non-device-backed qvm's

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -23,7 +23,7 @@ background.
 
     from pyquil import Program, get_qc
     from pyquil.gates import *
-    qvm = get_qc('9q-generic-qvm')
+    qvm = get_qc('9q-square-qvm')
 
 
 Now that our local endpoints are up and running, we can start running pyQuil programs! Open a jupyter notebook (type

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -59,7 +59,7 @@ program on the Quantum Virtual Machine, or QVM:
 
 .. code:: python
 
-    qvm = get_qc('9q-generic-qvm')
+    qvm = get_qc('9q-square-qvm')
     result = qvm.run_and_measure(p, trials=10)
     print(result)
 

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -28,7 +28,7 @@ using the instance method ``.compile()``, as in the following:
     from pyquil.api import get_qc
     from pyquil.gates import CNOT, H
 
-    qc = get_qc("9q-generic-qvm")
+    qc = get_qc("9q-square-qvm")
 
     ep = qc.compile(Program(H(0), CNOT(0,1), CNOT(1,2)))
 
@@ -79,7 +79,7 @@ the previous example snippet is identical to the following:
     from pyquil.api import get_qc
     from pyquil.gates import CNOT, H
 
-    qc = get_qc("9q-generic-qvm")
+    qc = get_qc("9q-square-qvm")
 
     p = Program(H(0), CNOT(0,1), CNOT(1,2))
     np = qc.compiler.quil_to_native_quil(p)

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -31,7 +31,7 @@ The QVM is available on your local machine. You can initialize a localQVM instan
 
     from pyquil import get_qc, Program
     from pyquil.gates import *
-    qvm = get_qc('9q-generic-qvm')
+    qvm = get_qc('9q-square-qvm')
 
 
 One executes quantum programs on the QVM using two paradigms: the ``.run(...)`` method, and

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -271,7 +271,7 @@ an entangled state between qubits 0 and 1 (that's what the "CNOT" gate does). Ne
 .. code:: python
 
     # run the program on a QVM
-    qvm = get_qc('9q-generic-qvm')
+    qvm = get_qc('9q-square-qvm')
     result = qvm.run_and_measure(p, trials=10)
     print(result)
 
@@ -612,7 +612,7 @@ can be changed to
     from pyquil.api import get_qc
 
     def setup_forest_objects():
-        qc = get_qc("9q-generic-qvm")
+        qc = get_qc("9q-square-qvm")
         return qc
 
 and the references to ``qvm`` in the main body are changed to ``qc`` instead. Since the ``QuantumComputer`` object also
@@ -721,7 +721,7 @@ Overall, the resulting program looks like this:
 
 
     def setup_forest_objects():
-        qc = get_qc("9q-generic-qvm")
+        qc = get_qc("9q-square-qvm")
         return qc
 
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -306,7 +306,7 @@ def _get_qvm_compiler_based_on_endpoint(endpoint: str = None,
         raise ValueError("Protocol for QVM compiler endpoints must be HTTP or TCP.")
 
 
-def _get_9q_generic_qvm(connection: ForestConnection, noisy: bool) -> QuantumComputer:
+def _get_9q_square_qvm(connection: ForestConnection, noisy: bool) -> QuantumComputer:
     """
     A nine-qubit 3x3 square lattice.
 
@@ -450,7 +450,7 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
 
         if not as_qvm:
             raise ValueError("The device '9q-square' is only available as a QVM")
-        return _get_9q_generic_qvm(connection=connection, noisy=noisy)
+        return _get_9q_square_qvm(connection=connection, noisy=noisy)
 
     device = get_lattice(name)
     if not as_qvm:

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -347,7 +347,7 @@ def _get_unrestricted_qvm(connection: ForestConnection, noisy: bool, n_qubits: i
     else:
         noise_model = None
 
-    return QuantumComputer(name='9q-generic-qvm', # TODO: fix
+    return QuantumComputer(name=f'{n_qubits}q-qvm',
                            qam=QVM(connection=connection, noise_model=noise_model),
                            device=fully_connected_device,
                            compiler=_get_qvm_compiler_based_on_endpoint(

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -347,7 +347,7 @@ def _get_unrestricted_qvm(connection: ForestConnection, noisy: bool, n_qubits: i
     else:
         noise_model = None
 
-    return QuantumComputer(name='9q-generic-qvm',
+    return QuantumComputer(name='9q-generic-qvm', # TODO: fix
                            qam=QVM(connection=connection, noise_model=noise_model),
                            device=fully_connected_device,
                            compiler=_get_qvm_compiler_based_on_endpoint(
@@ -421,12 +421,17 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
 
     name, as_qvm, noisy = _parse_name(name, as_qvm, noisy)
 
-    if name == '':
-        if not as_qvm:
-            raise ValueError("Please name a valid device or run as a QVM")
-        return _get_unrestricted_qvm(connection=connection, noisy=noisy)
+    if name[-1] == 'q':
+        try:
+            n_qubits = int(name[:-1])
+            if not as_qvm:
+                raise ValueError("Please name a valid device or run as a QVM")
+            return _get_unrestricted_qvm(connection=connection, noisy=noisy, n_qubits=n_qubits)
+        except ValueError: # TODO: what goes here
+            pass
 
-    if name == '9q-generic':
+    if name == '9q-generic' or name == '9q-square':
+        # TODO: deprecate '9q-generic'
         if not as_qvm:
             raise ValueError("The device '9q-generic' is only available as a QVM")
         return _get_9q_generic_qvm(connection=connection, noisy=noisy)

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -246,6 +246,7 @@ def test_nq_qvm_qc():
         qc = get_qc(f'{n_qubits}q-qvm')
         for q1, q2 in itertools.permutations(range(n_qubits), r=2):
             assert (q1, q2) in qc.qubit_topology().edges
+        assert qc.name == f'{n_qubits}q-qvm'
 
 
 def test_run_and_measure_concat(qvm, compiler):

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -241,10 +241,11 @@ def test_qc(qvm, compiler):
         assert bits.shape == (3,)
 
 
-def test_fully_connected_qvm_qc():
-    qc = get_qc('qvm')
-    for q1, q2 in itertools.permutations(range(34), r=2):
-        assert (q1, q2) in qc.qubit_topology().edges
+def test_nq_qvm_qc():
+    for n_qubits in [2, 4, 7, 19]:
+        qc = get_qc(f'{n_qubits}q-qvm')
+        for q1, q2 in itertools.permutations(range(n_qubits), r=2):
+            assert (q1, q2) in qc.qubit_topology().edges
 
 
 def test_run_and_measure_concat(qvm, compiler):


### PR DESCRIPTION
The party line is that you should be using qvm's based on real chips. In the absence of the release of those chips, their connectivities, and noise models we provided `get_qc("9q-generic-qvm")` which may have been a big too *generic* of a name.

Now you can `get_qc("9q-square-qvm")` which gives you a 3x3 square lattice (this is what 9q-generic used to be) (9q-generic is kept for compatibility now but will probably be removed soon since it only ever appeared in a beta release). You can also break free of the shackles of a topology with `get_qc("nq-qvm")` where `n` is an integer, e.g. `get_qc("20q-qvm")`. This replaces `get_qc("qvm")` which would under-the-hood construct a 34-qubit topology which broke `run_and_measure` following #561 

cc @ryankarle @tmittal947 @gecrooks 