### PR TITLE
Improve messages for errors running programs

### DIFF
--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -13,6 +13,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+import warnings
+
 from abc import ABC, abstractmethod
 
 from rpcq.messages import ParameterAref
@@ -52,7 +54,9 @@ class QAM(ABC):
 
         :param executable: Load a compiled executable onto the QAM.
         """
-        assert self.status in ['connected', 'done']
+        if self.status == 'loaded':
+            warnings.warn("Overwriting previously loaded executable.")
+        assert self.status in ['connected', 'done', 'loaded']
 
         self._variables_shim = {}
         self._executable = executable

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 ##############################################################################
 import uuid
+import warnings
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
@@ -110,6 +111,11 @@ class QPU(QAM):
 
         if results:
             bitstrings = _extract_bitstrings(ro_sources, results)
+        elif not ro_sources:
+            warnings.warn("You are running a QPU program with no MEASURE instructions. "
+                          "The result of this program will always be an empty array. Are "
+                          "you sure you didn't mean to measure some of your qubits?")
+            bitstrings = np.zeros((0, 0), dtype=np.int64)
         else:
             bitstrings = None
 

--- a/pyquil/api/_qvm.py
+++ b/pyquil/api/_qvm.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 ##############################################################################
 import warnings
+import numpy as np
 from typing import List
 
 from rpcq.messages import PyQuilExecutableResponse
@@ -437,12 +438,18 @@ To read more about supplying noise to the QVM, see http://pyquil.readthedocs.io/
             quil_program = apply_noise_model(quil_program, self.noise_model)
 
         quil_program = self.augment_program_with_memory_values(quil_program)
-        self._bitstrings = self.connection._qvm_run(quil_program=quil_program,
-                                                    classical_addresses=classical_addresses,
-                                                    trials=trials,
-                                                    measurement_noise=self.measurement_noise,
-                                                    gate_noise=self.gate_noise,
-                                                    random_seed=self.random_seed)['ro']
+        try:
+            self._bitstrings = self.connection._qvm_run(quil_program=quil_program,
+                                                        classical_addresses=classical_addresses,
+                                                        trials=trials,
+                                                        measurement_noise=self.measurement_noise,
+                                                        gate_noise=self.gate_noise,
+                                                        random_seed=self.random_seed)['ro']
+        except KeyError:
+            warnings.warn("You are running a QVM program with no MEASURE instructions. "
+                          "The result of this program will always be an empty array. Are "
+                          "you sure you didn't mean to measure some of your qubits?")
+            self._bitstrings = np.zeros((trials, 0), dtype=np.int64)
 
         return self
 

--- a/pyquil/tests/test_qpu.py
+++ b/pyquil/tests/test_qpu.py
@@ -25,11 +25,13 @@ def test_qpu_run():
                              compiler=QPUCompiler(endpoint=config.compiler_url,
                                                   device=device))
         bitstrings = qc.run_and_measure(
-            quil_program=Program(X(0)),
+            program=Program(X(0)),
             trials=1000,
         )
-        assert bitstrings.shape == (1000, 1)
-        assert np.mean(bitstrings) > 0.8
+        assert bitstrings[0].shape == (1000,)
+        assert np.mean(bitstrings[0]) > 0.8
+        bitstrings = qc.run(qc.compile(Program(X(0))))
+        assert bitstrings.shape == (0, 0)
     else:
         pytest.skip("QPU or compiler-server not available; skipping QPU run test.")
 

--- a/pyquil/tests/test_qvm.py
+++ b/pyquil/tests/test_qvm.py
@@ -23,6 +23,15 @@ def test_qvm_run(forest: ForestConnection):
     assert np.mean(bitstrings) > 0.8
 
 
+def test_qvm_run_no_measure(forest: ForestConnection):
+    qvm = QVM(connection=forest)
+    p = Program(X(0))
+    nq = PyQuilExecutableResponse(program=p.out(), attributes={'num_shots': 100})
+    qvm.load(nq).run().wait()
+    bitstrings = qvm.read_from_memory_region(region_name="ro")
+    assert bitstrings.shape == (100, 0)
+
+
 def test_roundtrip_pyquilexecutableresponse():
     p = Program(H(10), CNOT(10, 11))
     lcqvm = LocalQVMCompiler(endpoint=None, device=NxDevice(nx.complete_graph(3)))


### PR DESCRIPTION
Fixes issue #580 
- If you call QuantumComputer.run with a program that has no measurements, you'll get an empty array (shape=(number of trials, 0))
- Also ran into this issue while testing: if you load a program twice, you will get a descriptive warning rather than an assertion error with no message