### PR TITLE
AbstractCompiler.get_version_info not as "abstract"

### DIFF
--- a/pyquil/api/_qac.py
+++ b/pyquil/api/_qac.py
@@ -22,13 +22,13 @@ from pyquil.paulis import PauliTerm
 
 
 class AbstractCompiler(ABC):
-    @abstractmethod
     def get_version_info(self) -> dict:
         """
         Return version information for this compiler and its dependencies.
 
         :return: Dictionary of version information.
         """
+        raise NotImplementedError
 
     @abstractmethod
     def quil_to_native_quil(self, program: Program) -> Program:


### PR DESCRIPTION
@abstractmethod is too aggressive. This change means that implementors
don't need to implement this function at class definition time. It
will still raise an error if someone tries to *use* it and it's not
defined, though.