### PR TITLE
Rename the QAM method read_from_memory_region to read_memory

### DIFF
--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -399,7 +399,7 @@ becomes
         qc.qam.write_memory(region_name='theta', value=angle_min + offset * angle_step)
         qc.qam.run()
         qc.qam.wait()
-        bitstrings = qc.qam.read_from_memory_region(region_name="ro", offsets=True)
+        bitstrings = qc.qam.read_memory(region_name="ro")
 
         totals = [0, 0, 0, 0]
         for bitstring in bitstrings:
@@ -481,7 +481,7 @@ Overall, the resulting program looks like this:
         qc.qam.write_memory(region_name='theta', value=angle_min + offset * angle_step)
         qc.qam.run()
         qc.qam.wait()
-        bitstrings = qc.qam.read_from_memory_region(region_name="ro", offsets=True)
+        bitstrings = qc.qam.read_memory(region_name="ro")
 
         totals = [0, 0, 0, 0]
         for bitstring in bitstrings:

--- a/examples/forest2-simple-prog.py
+++ b/examples/forest2-simple-prog.py
@@ -89,7 +89,7 @@ def run_bell_low_level(n_shots=1000):
     bitstrings = qam.load(executable) \
         .run() \
         .wait() \
-        .read_from_memory_region(region_name="ro")
+        .read_memory(region_name="ro")
 
     # Bincount bitstrings
     basis = np.array([2 ** i for i in range(len(q))])

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -99,7 +99,7 @@ class QAM(ABC):
         return self
 
     @_record_call
-    def read_from_memory_region(self, *, region_name: str):
+    def read_memory(self, *, region_name: str):
         """
         Reads from a memory region named region_name on the QAM.
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -116,3 +116,25 @@ class QAM(ABC):
             raise QAMError("Bitstrings have not yet been populated. Something has gone wrong.")
 
         return self._bitstrings
+
+    @_record_call
+    def read_from_memory_region(self, *, region_name: str):
+        """
+        Reads from a memory region named region_name on the QAM.
+
+        This is a shim over the eventual API and only can return memory from a region named
+        "ro" of type ``BIT``.
+
+        :param region_name: The string naming the declared memory region.
+        :return: A list of values of the appropriate type.
+        """
+        warnings.warn("pyquil.api._qam.QAM.read_from_memory_region is deprecated, please use "
+                      "pyquil.api._qam.QAM.read_memory instead.",
+                      DeprecationWarning)
+        assert self.status == 'done'
+        if region_name != "ro":
+            raise QAMError("Currently only allowed to read measurement data from ro.")
+        if self._bitstrings is None:
+            raise QAMError("Bitstrings have not yet been populated. Something has gone wrong.")
+
+        return self._bitstrings

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -133,7 +133,7 @@ class QuantumComputer:
         return self.qam.load(executable) \
             .run() \
             .wait() \
-            .read_from_memory_region(region_name="ro")
+            .read_memory(region_name="ro")
 
     @_record_call
     def run_symmetrized_readout(self, program: Program, trials: int) -> np.ndarray:

--- a/pyquil/tests/test_qvm.py
+++ b/pyquil/tests/test_qvm.py
@@ -19,7 +19,7 @@ def test_qvm_run_pqer(forest: ForestConnection):
     qvm.load(nq)
     qvm.run()
     qvm.wait()
-    bitstrings = qvm.read_from_memory_region(region_name="ro")
+    bitstrings = qvm.read_memory(region_name="ro")
     assert bitstrings.shape == (1000, 1)
     assert np.mean(bitstrings) > 0.8
 
@@ -31,7 +31,7 @@ def test_qvm_run_just_program(forest: ForestConnection):
     qvm.load(p)
     qvm.run()
     qvm.wait()
-    bitstrings = qvm.read_from_memory_region(region_name="ro")
+    bitstrings = qvm.read_memory(region_name="ro")
     assert bitstrings.shape == (1000, 1)
     assert np.mean(bitstrings) > 0.8
 
@@ -51,7 +51,7 @@ def test_qvm_run_only_pqer(forest: ForestConnection):
     qvm.load(nq)
     qvm.run()
     qvm.wait()
-    bitstrings = qvm.read_from_memory_region(region_name="ro")
+    bitstrings = qvm.read_memory(region_name="ro")
     assert bitstrings.shape == (1000, 1)
     assert np.mean(bitstrings) > 0.8
 
@@ -61,7 +61,7 @@ def test_qvm_run_no_measure(forest: ForestConnection):
     p = Program(X(0))
     nq = PyQuilExecutableResponse(program=p.out(), attributes={'num_shots': 100})
     qvm.load(nq).run().wait()
-    bitstrings = qvm.read_from_memory_region(region_name="ro")
+    bitstrings = qvm.read_memory(region_name="ro")
     assert bitstrings.shape == (100, 0)
 
 


### PR DESCRIPTION
To match the language of `write_memory`.