### PR TITLE
First batch of API docs

### DIFF
--- a/docs/source/_templates/autosumm.rst
+++ b/docs/source/_templates/autosumm.rst
@@ -1,0 +1,5 @@
+{{ objname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/docs/source/apidocs/.gitignore
+++ b/docs/source/apidocs/.gitignore
@@ -1,0 +1,1 @@
+/autogen

--- a/docs/source/apidocs/compilers.rst
+++ b/docs/source/apidocs/compilers.rst
@@ -1,0 +1,20 @@
+Compilers
+=========
+
+An appropriate compiler is automatically created when using :py:func:`~pyquil.get_qc` and it is
+stored on the :py:class:`~pyquil.api.QuantumComputer` object as the ``compiler`` attribute.
+
+The exact process for compilation depends on whether you're targeting a QPU or a QVM, and
+you can conceive of other compilation strategies than those included with pyQuil by default.
+Therefore, we define an abstract interface that all compilers must follow. See
+:py:class:`~pyquil.api._qac.AbstractCompiler` for more, or use one of the listed compilers below.
+
+
+.. currentmodule:: pyquil.api
+.. autosummary::
+    :toctree: autogen
+
+    _qac.AbstractCompiler
+    QVMCompiler
+    LocalQVMCompiler
+    QPUCompiler

--- a/docs/source/apidocs/devices.rst
+++ b/docs/source/apidocs/devices.rst
@@ -1,0 +1,36 @@
+Devices
+=======
+
+An appropriate Device is automatically created when using :py:func:`~pyquil.get_qc` and it is
+stored on the :py:class:`~pyquil.api.QuantumComputer` object as the ``device`` attribute.
+
+There are properties of real quantum computers that go beyond the quantum abstract machine
+(QAM) abstraction. Real devices have performance specs, limited ISAs, and restricted topologies.
+:py:class:`~pyquil.device.AbstractDevice` provides an abstract interface for accessing
+properties of a real quantum device or for mocking out relevant properties for a more realistic
+QVM.
+
+
+.. currentmodule:: pyquil.device
+.. autosummary::
+    :toctree: autogen
+
+    AbstractDevice
+    Device
+    NxDevice
+
+The data structures used are documented here
+
+.. autosummary::
+    :toctree: autogen
+
+    ISA
+    Specs
+
+Utility functions
+~~~~~~~~~~~~~~~~~
+
+.. autofunction:: isa_from_graph
+.. autofunction:: specs_from_graph
+.. autofunction:: isa_to_graph
+.. autofunction:: gates_in_isa

--- a/docs/source/apidocs/qam.rst
+++ b/docs/source/apidocs/qam.rst
@@ -1,0 +1,18 @@
+QAMs
+====
+
+An appropriate QAM is automatically created when using :py:func:`~pyquil.get_qc` and it is
+stored on the :py:class:`~pyquil.api.QuantumComputer` object as the ``qam`` attribute.
+
+The Quantum Abstract Machine (QAM) provides an abstract interface for running hybrid
+quantum/classical quil programs on either a Quantum Virtual Machine (QVM, a classical simulator)
+or a Quantum Processor Unit (QPU, a real quantum device).
+
+
+.. currentmodule:: pyquil.api
+.. autosummary::
+    :toctree: autogen
+
+    _qam.QAM
+    QPU
+    QVM

--- a/docs/source/apidocs/quantum_computer.rst
+++ b/docs/source/apidocs/quantum_computer.rst
@@ -11,7 +11,7 @@ Quantum Computer
    .. rubric:: Methods
 
    .. autosummary::
-        :toctree: QuantumComputer
+        :toctree: autogen
         :template: autosumm.rst
 
         ~QuantumComputer.run

--- a/docs/source/apidocs/quantum_computer.rst
+++ b/docs/source/apidocs/quantum_computer.rst
@@ -1,0 +1,23 @@
+.. currentmodule:: pyquil.api
+
+Quantum Computer
+================
+
+.. autofunction:: pyquil.get_qc
+.. autofunction:: pyquil.list_quantum_computers
+
+.. autoclass:: pyquil.api.QuantumComputer
+
+   .. rubric:: Methods
+
+   .. autosummary::
+        :toctree: QuantumComputer
+        :template: autosumm.rst
+
+        ~QuantumComputer.run
+        ~QuantumComputer.run_and_measure
+        ~QuantumComputer.run_symmetrized_readout
+        ~QuantumComputer.qubits
+        ~QuantumComputer.qubit_topology
+        ~QuantumComputer.get_isa
+        ~QuantumComputer.compile

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
@@ -38,27 +39,14 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx_autodoc_typehints',
 ]
+
+autosummary_generate = True
+autoclass_content = "init"
 
 import sphinx_rtd_theme
 from pyquil import __version__
-
-
-def remove_secrets(app, what, name, obj, options, signature, return_annotation):
-    if what == "class" and name == "pyquil.api.Connection":
-        import pyquil.api as pqf
-        print("Replacing endpoint secrets in pyquil.api.Connection() signature")
-        print(signature,)
-        signature = signature.replace("'{}'".format(pqf.ENDPOINT), "ENDPOINT")
-        signature = signature.replace("'{}'".format(pqf.API_KEY), "API_KEY")
-        signature = signature.replace("'{}'".format(pqf.USER_ID), "USER_ID")
-        print("--> ", signature)
-        return signature, return_annotation
-
-
-def setup(app):
-    app.connect("autodoc-process-signature", remove_secrets)
-
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -141,7 +129,6 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -267,21 +254,21 @@ htmlhelp_basename = 'pyQuildoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
-     #
-     # 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
 
-     # The font size ('10pt', '11pt' or '12pt').
-     #
-     # 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
 
-     # Additional stuff for the LaTeX preamble.
-     #
-     # 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
 
-     # Latex figure (float) alignment
-     #
-     # 'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
 ]
 
 autosummary_generate = True
-autoclass_content = "init"
+autoclass_content = "both"
 
 import sphinx_rtd_theme
 from pyquil import __version__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,6 +86,7 @@ Contents
 
    apidocs/quantum_computer
    apidocs/compilers
+   apidocs/qam
 
 
 Indices and Tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,6 +87,7 @@ Contents
    apidocs/quantum_computer
    apidocs/compilers
    apidocs/qam
+   apidocs/devices
 
 
 Indices and Tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,6 +80,12 @@ Contents
    changes
    intro
 
+.. toctree::
+   :maxdepth: 3
+   :caption: API Reference
+
+   apidocs/quantum_computer
+
 
 Indices and Tables
 ------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,7 @@ Contents
    :caption: API Reference
 
    apidocs/quantum_computer
+   apidocs/compilers
 
 
 Indices and Tables

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,14 +1,6 @@
 Source Code Documentation
 =========================
 
-pyquil.api
-----------
-
-.. automodule:: pyquil.api
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 pyquil.device
 -------------
 

--- a/pyquil/api/_qac.py
+++ b/pyquil/api/_qac.py
@@ -22,6 +22,8 @@ from pyquil.paulis import PauliTerm
 
 
 class AbstractCompiler(ABC):
+    """The abstract interface for a compiler."""
+
     def get_version_info(self) -> dict:
         """
         Return version information for this compiler and its dependencies.

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -471,7 +471,7 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
         the default values for URL endpoints, ping time, and status time will be used. Your
         user id and API key will be read from ~/.pyquil_config. If you deign to change any
         of these parameters, pass your own :py:class:`ForestConnection` object.
-    :return:
+    :return: A pre-configured QuantumComputer
     """
     if connection is None:
         connection = ForestConnection()

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -113,13 +113,32 @@ class QuantumComputer:
         self.symmetrize_readout = symmetrize_readout
 
     def qubits(self) -> List[int]:
+        """
+        Return a sorted list of this QuantumComputer's device's qubits
+
+        See :py:func:`AbstractDevice.qubits` for more.
+        """
         return self.device.qubits()
 
     def qubit_topology(self) -> nx.graph:
+        """
+        Return a NetworkX graph representation of this QuantumComputer's device's qubit
+        connectivity.
+
+        See :py:func:`AbstractDevice.qubit_topology` for more.
+        """
         return self.device.qubit_topology()
 
     def get_isa(self, oneq_type: str = 'Xhalves',
                 twoq_type: str = 'CZ') -> ISA:
+        """
+        Return a target ISA for this QuantumComputer's device.
+
+        See :py:func:`AbstractDevice.get_isa` for more.
+
+        :param oneq_type: The family of one-qubit gates to target
+        :param twoq_type: The family of two-qubit gates to target
+        """
         return self.device.get_isa(oneq_type=oneq_type, twoq_type=twoq_type)
 
     @_record_call
@@ -216,6 +235,20 @@ class QuantumComputer:
     def compile(self, program: Program,
                 to_native_gates: bool = True,
                 optimize: bool = True) -> Message:
+        """
+        A high-level interface to program compilation.
+
+        Compilation currently consists of two stages. Please see the :py:class:`AbstractCompiler`
+        docs for more information. This function does all stages of compilation.
+
+        Right now both ``to_native_gates`` and ``optimize`` must be either both set or both
+        unset. More modular compilation passes may be available in the future.
+
+        :param program: A Program
+        :param to_native_gates: Whether to compile non-native gates to native gates.
+        :param optimize: Whether to optimize programs to reduce the number of operations.
+        :return:
+        """
         flags = [to_native_gates, optimize]
         assert all(flags) or all(not f for f in flags), "Must turn quilc all on or all off"
         quilc = all(flags)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -247,7 +247,7 @@ class QuantumComputer:
         :param program: A Program
         :param to_native_gates: Whether to compile non-native gates to native gates.
         :param optimize: Whether to optimize programs to reduce the number of operations.
-        :return:
+        :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
         flags = [to_native_gates, optimize]
         assert all(flags) or all(not f for f in flags), "Must turn quilc all on or all off"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tox
 # docs
 sphinx
 sphinx_rtd_theme
+sphinx_autodoc_typehints


### PR DESCRIPTION
Wrangle sphinx autosummary and sprinkle in some organization and cross-referencing.

This PR contains the building-block `pyquil.api` classes and functions. We should grind through everything currently documented in `modules.rst` and give it some structure.

I encourage reviewers to pull this branch and build the docs. They're pretty snazzy!