### PR TITLE
Add man pages, cleanup QVM page

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -118,6 +118,7 @@ The following gates methods come standard with Quil and ``gates.py``:
 The parameterized gates take a real or complex floating point
 number as an argument.
 
+.. _declaring_memory:
 
 Declaring Memory
 ~~~~~~~~~~~~~~~~

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -18,9 +18,34 @@ hardware.
 Interacting with the Compiler
 -----------------------------
 
+After :ref:`downloading the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your local machine.
+You can initialize a local ``quilc`` server by typing ``quilc -S`` into your terminal. You should see the following message.
+
+.. code:: python
+
+    $ quilc -S
+    +-----------------+
+    |  W E L C O M E  |
+    |   T O   T H E   |
+    |  R I G E T T I  |
+    |     Q U I L     |
+    | C O M P I L E R |
+    +-----------------+
+    Copyright (c) 2018 Rigetti Computing.
+
+    This is a part of the Forest SDK. By using this program
+    you agree to the End User License Agreement (EULA) supplied
+    with this program. If you did not receive the EULA, please
+    contact <support@rigetti.com>.
+
+    [2018-11-06 10:59:22] Starting server: 0.0.0.0 : 6000.
+
+To get a description of ``quilc``, and options and examples of its command line use, see :ref:`quilc_man`.
+
+
 A ``QuantumComputer`` object supplied by the function ``pyquil.api.get_qc()`` comes equipped with a
-connection to a Rigetti Quil compiler.  This can be accessed
-using the instance method ``.compile()``, as in the following:
+connection to your local Rigetti Quil compiler.  This can be accessed using the instance method ``.compile()``,
+as in the following:
 
 .. code:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,6 +90,7 @@ Contents
    apidocs/devices
 
 .. toctree::
+   :caption: Man Pages
    :maxdepth: 1
 
    qvm-man

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,6 +89,12 @@ Contents
    apidocs/qam
    apidocs/devices
 
+.. toctree::
+   :maxdepth: 1
+
+   qvm-man
+   quilc-man
+
 
 Indices and Tables
 ------------------

--- a/docs/source/quilc-man.rst
+++ b/docs/source/quilc-man.rst
@@ -1,0 +1,134 @@
+.. _quilc_man:
+
+QUILC Man Page
+==============
+
+NAME
+====
+
+``quilc`` - an optimizing, architecture-independent Quil compiler
+
+SYNOPSIS
+========
+
+``quilc <options>``
+
+DESCRIPTION
+===========
+
+The Rigetti Quil compiler, ``quilc``, is an optimizing compiler for Quil. It
+takes a general Quil program along with a qubit architecture, called an
+ISA, and produces another Quil program that is executable on that
+architecture. The compiler will also attempt to optimize the program by
+producing fewer gates and shorter gate depths. The compiler may either
+be run as a server which takes requests (as is used with PyQuil), or it
+may be run as a batch program reading from standard input.
+
+Server Mode runs the compiler as an HTTP server, taking simple POST
+requests with JSON payloads which are known to the companion library
+pyQuil.
+
+OPTIONS
+=======
+
+``-S, --server``
+      (Server Mode) Run the compiler in Server Mode. This starts an HTTP server.
+
+``-?, -h, --help``
+      Show the help message.
+
+``-v, --version``
+      Show the version.
+
+``--verbose``
+      Print what the compiler is thinking. (Warning: It thinks a lot.)
+
+``--isa <string>``
+      Compile  for  the  qubit  architecture  defined  by  <string>,  which can be either 8Q, 20Q, 16QMUX, or a path to a QPU
+      description file.
+
+``-p, --protoquil``
+      Prescribe that the input and output must be ProtoQuil, which is Quil that is comprised of gates and measurements,  with
+      no control flow.
+
+``--port <port>``
+      (Server Mode) Run quilc in server mode on port <port>.
+
+``-d, --compute-gate-depth``
+      Print a calculated gate depth for the provided circuit as an appended Quil comment. (Requires -p.)
+
+``-2, --compute-2Q-gate-depth``
+      Print  a  calculated  multiqubit gate depth for the provided circuit as an appended Quil comment. (Requires -p. Ignores
+      the blacklist and whitelist.)
+
+``--compute-gate-volume``
+      Print a calculated gate volume for the provided circuit as an appended Quil comment. (Requires -p.)
+
+``-r, --compute-runtime``
+      Print a calculated estimated runtime for the provided circuit as an appended Quil comment. (Requires -p.)
+
+``-f, --compute-fidelity``
+      Print a calculated estimated compiled circuit fidelity for the provided circuit as an appended Quil comment.  (Requires
+      -p.)
+
+``-u, --compute-unused-qubits``
+      Print a list of unused qubits as an appended Quil comment. (Requires -p.)
+
+``-t, --show-topological-overhead``
+      Print  the  number of SWAP gates incurred for topological reasons for the provided circuit as an appended Quil comment.
+      (Requires -p.)
+
+``--gate-blacklist <gate-list>``
+      When calculating statistics, ignore the gates present in the comma-separated list of names of <gate-list>.
+
+``--gate-whitelist <gate-list>``
+      When calculating statistics, consider only the gates present in the comma-separated list of names of <gate-list>.
+
+``--time-limit <limit-ms>``
+      (Server Mode) Limit the amount of time for a single request to approximately <limit-ms> milliseconds. By default,  this
+      value is 0, which indicates an unlimited amount of time is allowed.
+
+``--without-pretty-printing``
+      Disable pretty printing of numerical quantities (e.g., multiples of pi) in compiled output.
+
+``--prefer-gate-ladders``
+      Use gate ladders, instead of the SWAP gate, to implement long-ranged gates, when possible.
+
+``-j, --json-serialize``
+      Serialize the output of compilation as a JSON object.
+
+``-s, --print-logical-schedule``
+      Include the logically parallelized schedule in JSON output. (Requires -p.)
+
+``-m, --compute-matrix-reps``
+      Print  the  matrix  representation  of  a compiled ProtoQuil program. Additionally, verify that this matrix matches the
+      matrix representation of the input program. (Requires -p. Note that this is a very expensive operation.)
+
+``--enable-state-prep-reductions``
+      Perform program optimizations by assuming that the quantum state starts in the zero state.
+
+EXAMPLES
+========
+
+``quilc --isa "8Q" < file.quil``
+      Compile a Quil file (printing the result to stdout) for an eight qubit ring.
+
+SUPPORT
+=======
+
+Contact <support@rigetti.com>.
+
+COPYRIGHT
+=========
+
+Copyright (c) 2018 Rigetti Computing
+
+SEE ALSO
+========
+
+:ref:`qvm(1) <qvm_man>`
+
+0.13.0 (cl-quil: 0.19.0) [e9b41e3]                        24 September 2018                                                  QUILC(1)
+
+
+

--- a/docs/source/quilc-man.rst
+++ b/docs/source/quilc-man.rst
@@ -4,17 +4,17 @@ QUILC Man Page
 ==============
 
 NAME
-====
+~~~~
 
 ``quilc`` - an optimizing, architecture-independent Quil compiler
 
 SYNOPSIS
-========
+~~~~~~~~
 
 ``quilc <options>``
 
 DESCRIPTION
-===========
+~~~~~~~~~~~
 
 The Rigetti Quil compiler, ``quilc``, is an optimizing compiler for Quil. It
 takes a general Quil program along with a qubit architecture, called an
@@ -29,7 +29,7 @@ requests with JSON payloads which are known to the companion library
 pyQuil.
 
 OPTIONS
-=======
+~~~~~~~
 
 ``-S, --server``
       (Server Mode) Run the compiler in Server Mode. This starts an HTTP server.
@@ -108,23 +108,23 @@ OPTIONS
       Perform program optimizations by assuming that the quantum state starts in the zero state.
 
 EXAMPLES
-========
+~~~~~~~~
 
 ``quilc --isa "8Q" < file.quil``
       Compile a Quil file (printing the result to stdout) for an eight qubit ring.
 
 SUPPORT
-=======
+~~~~~~~
 
 Contact <support@rigetti.com>.
 
 COPYRIGHT
-=========
+~~~~~~~~~
 
 Copyright (c) 2018 Rigetti Computing
 
 SEE ALSO
-========
+~~~~~~~~
 
 :ref:`qvm(1) <qvm_man>`
 

--- a/docs/source/qvm-man.rst
+++ b/docs/source/qvm-man.rst
@@ -4,12 +4,12 @@ QVM Man Page
 ============
 
 NAME
-====
+~~~~
 
 ``qvm`` - a quantum virtual machine for executing Quil
 
 SYNOPSIS
-========
+~~~~~~~~
 
 ``qvm <options> -e`` # Execute Mode
 
@@ -18,7 +18,7 @@ SYNOPSIS
 ``qvm <options> --benchmark [n]`` # Benchmark Mode
 
 DESCRIPTION
-===========
+~~~~~~~~~~~
 
 The Rigetti QVM is a high-performance, classical implementation of a
 quantum abstract machine. Specifically, it is capable of executing Quil
@@ -50,7 +50,7 @@ models. Instead, the Quil program itself specifies PRAGMAs for defining
 Kraus operators and readout POVMs.
 
 OPTIONS
-=======
+~~~~~~~
 
 ``-e, --execute``
       (Execute Mode) Run the QVM in Execute Mode. Execute the Quil program supplied from stdin  and  print  some  information
@@ -104,7 +104,7 @@ OPTIONS
 
 
 EXAMPLES
-========
+~~~~~~~~
 
 ``qvm -e < file.quil``
       Run a Quil file on the QVM.
@@ -119,24 +119,24 @@ EXAMPLES
       Benchmark a 25-qubit quantum Fourier transform in compiled mode.
 
 BUGS
-====
+~~~~
 
 Shared memory mode does not work with QVMs executing noisy programs (i.e., ones where Kraus operators or POVMs are specified).
 
 The WAIT instruction does nothing.
 
 SUPPORT
-=======
+~~~~~~~
 
 Contact <support@rigetti.com>.
 
 COPYRIGHT
-=========
+~~~~~~~~~
 
 Copyright (c) 2018 Rigetti Computing
 
 SEE ALSO
-========
+~~~~~~~~
 
 :ref:`quilc(1) <quilc_man>`
 

--- a/docs/source/qvm-man.rst
+++ b/docs/source/qvm-man.rst
@@ -1,0 +1,143 @@
+.. _qvm_man:
+
+QVM Man Page
+============
+
+NAME
+====
+
+``qvm`` - a quantum virtual machine for executing Quil
+
+SYNOPSIS
+========
+
+``qvm <options> -e`` # Execute Mode
+
+``qvm <options> -S`` # Server Mode
+
+``qvm <options> --benchmark [n]`` # Benchmark Mode
+
+DESCRIPTION
+===========
+
+The Rigetti QVM is a high-performance, classical implementation of a
+quantum abstract machine. Specifically, it is capable of executing Quil
+in a variety of ways. The QVM has three main modes of operation: Execute
+Mode, Server Mode, and Benchmark Mode.
+
+Execute Mode runs the QVM on a single Quil file, printing out
+information about the execution, as well as a textual representation of
+the wavefunction if ``--verbose`` is provided. (If one would like full
+access to the wavefunction as an efficient representation, one should
+use ``--shared``.)
+
+Server Mode runs the QVM as an HTTP server, taking simple POST requests
+with JSON payloads which are known to the companion library PyQuil. The
+server is useful even to a single user wishing to run a variety of
+computations.
+
+Benchmark Mode is used for stress testing the QVM on a computer.
+
+The QVM implements both a Quil interpreter and a just-in-time (JIT)
+compiler. (Note that "compilation" here does not refer to the sense
+related to translation of gate sets, but rather translation to machine
+code for rapid execution.) Interpreted mode is enabled by default and
+works for all modes of operation. JIT compilation is enabled by
+supplying the ``--compile`` option.
+
+The QVM does not have explicit options for running programs with noise
+models. Instead, the Quil program itself specifies PRAGMAs for defining
+Kraus operators and readout POVMs.
+
+OPTIONS
+=======
+
+``-e, --execute``
+      (Execute Mode) Run the QVM in Execute Mode. Execute the Quil program supplied from stdin  and  print  some  information
+      about the course of evaluation.
+
+``-S, --server``
+      (Server Mode) Run the QVM in Server Mode. This starts an HTTP server.
+
+``--benchmark [<n>]``
+      (Benchmark Mode) Run the QVM benchmark on <n> qubits. The default is 26.
+
+``-p <port>, --port <port>``
+      (Server Mode) Run the QVM server on port <port>. The default is 5000.
+
+``--memory-limit <num-octets>``
+      Limit the amount of classical memory to <num-octets> octets usable by an individual Quil program. The default is 65536.
+
+``-w <n>, --num-workers <n>``
+      Force the number of parallel workers to be <n>. By default, this is the number of logical cores of the host machine.
+
+``--time-limit <limit-ms>``
+      (Server  Mode) Limit the amount of time for a single request to approximately <limit-ms> milliseconds. By default, this
+      value is 0, which indicates an unlimited amount of time is allowed.
+
+``--qubit-limit <n>``
+      (Server Mode) Limit requests to consuming <n> qubits.
+
+``--benchmark-type <name>``
+      (Benchmark Mode) Run the benchmark named <name>. Benchmarks include "bell", "qft", "hadamard".
+
+``-h, --help``
+      Show the help message.
+
+``-v, --version``
+      Show the version.
+
+``--verbose``
+      Print every instruction transition of the QVM with information about timing and allocation.
+
+      (Execute Mode) Print each basis state and corresponding amplitude of the evolved wavefunction.
+
+``-c, --compile``
+      JIT compile the Quil programs to make them run faster.
+
+``--safe-include-directory <dir>``
+      Only allow <dir> to be included from with the Quil INCLUDE directive.
+
+``--shared <name>``
+      (Server Mode) Run the QVM in shared memory mode. This allocates the wavefunction in POSIX shared memory  named  <name>.
+      If <name> is an empty string, then a name will be generated. The --qubits argument must be specified.
+
+
+EXAMPLES
+========
+
+``qvm -e < file.quil``
+      Run a Quil file on the QVM.
+
+``printf "H 0\nCNOT 0 1\nCNOT 1 2" | qvm --verbose -e``
+      Create a 3-qubit Bell state, printing information about the execution along the way.
+
+``qvm -S -p 1234``
+      Start a QVM server for use with PyQuil on port 1234.
+
+``qvm -c --benchmark 25 --benchmark-type qft``
+      Benchmark a 25-qubit quantum Fourier transform in compiled mode.
+
+BUGS
+====
+
+Shared memory mode does not work with QVMs executing noisy programs (i.e., ones where Kraus operators or POVMs are specified).
+
+The WAIT instruction does nothing.
+
+SUPPORT
+=======
+
+Contact <support@rigetti.com>.
+
+COPYRIGHT
+=========
+
+Copyright (c) 2018 Rigetti Computing
+
+SEE ALSO
+========
+
+:ref:`quilc(1) <quilc_man>`
+
+version 0.16.0 (qvm: 0.20.0) [1b48c69]                    21 September 2018                                                    QVM(1)

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -8,27 +8,38 @@ The Quantum Virtual Machine (QVM)
 
 The Rigetti Quantum Virtual Machine is an implementation of the Quantum Abstract Machine from
 *A Practical Quantum Instruction Set Architecture*. [1]_  It is implemented in ANSI Common LISP and
-executes programs specified in the Quantum Instruction Language (Quil). Quil is an opinionated
-quantum instruction language: its basic belief is that in the near term quantum computers will
-operate as coprocessors, working in concert with traditional CPUs.  This means that Quil is
-designed to execute on a Quantum Abstract Machine that has a shared classical/quantum architecture
-at its core. The QVM is a wavefunction simulation of unitary evolution with classical control flow
+executes programs specified in the Quantum Instruction Language (Quil).
+
+Quil is an opinionated quantum instruction language: its basic belief is that in the near term quantum computers will
+operate as coprocessors, working in concert with traditional CPUs.  This means that Quil is designed to execute on
+a Quantum Abstract Machine that has a shared classical/quantum architecture at its core.
+
+The QVM is a wavefunction simulation of unitary evolution with classical control flow
 and shared quantum classical memory.
 
 .. _qvm_use:
 
 Using the QVM
 -------------
-After `downloading the SDK <https://www.rigetti.com/forest>`_, the QVM is available on your local machine. You can initialize a local
-QVM server by doing the following:
-
+After :ref:`downloading the SDK <sdkinstall>`, the QVM is available on your local machine. You can initialize a local
+QVM server by typing ``qvm -S`` into your terminal. You should see the following message.
 
 .. code:: python
-    $ qvm -S
-    Configured with 2048 MiB of workspace and 8 workers.)
-    [2018-09-20 15:39:50] Starting server on port 5000.
 
-Once the QVM is serving requests, we can run the following pyQuil program to get a ``QuantumComputer`` object
+    $ qvm -S
+    ******************************
+    * Welcome to the Rigetti QVM *
+    ******************************
+    Copyright (c) 2018 Rigetti Computing.
+
+    (Configured with 2048 MiB of workspace and 8 workers.)
+
+    [2018-11-06 18:18:18] Starting server on port 5000.
+
+For a detailed description of how to use the ``qvm`` from the command line, see :ref:`The QVM manual page <qvm_man>`.
+
+Once the QVM is serving requests, we can run the following pyQuil program to get a ``QuantumComputer`` object which
+will use the QVM.
 
 .. code:: python
 
@@ -37,17 +48,17 @@ Once the QVM is serving requests, we can run the following pyQuil program to get
     qc = get_qc('9q-square-qvm')
 
 
-One executes quantum programs on the QVM using a ``.run(...)`` method, intended to closely mirror how one will execute programs on a
-real QPU (check out `our website to see current and legacy QPUs <rigetti.com/qpu>`_). We also offer a Wavefunction Simulator
-(formerly a part of the QVM object), which allows users to contruct and inspect wavefunctions of quantum programs. Learn more
-about :ref:`wavefunction_simulator`.
-
-(For information on constructing quantum programs, please refer back to :ref:`basics`.)
+One executes quantum programs on the QVM using the ``.run(...)`` method, intended to closely mirror how one will
+execute programs on a real QPU. We also offer a Wavefunction Simulator (formerly a part of the ``QVM`` object),
+which allows users to contruct and inspect wavefunctions of quantum programs. Learn more
+about the Wavefunction Simulator :ref:`here <wavefunction_simulator>`. For information on constructing quantum
+programs, please refer back to :ref:`basics`.
 
 The ``.run(...)`` method
 ------------------------
 
 The ``.run(...)`` method takes in a compiled program. You are responsible for compiling your program before running it.
+Remember to also start up a ``quilc`` compiler server, too, with ``quilc -S``.
 
 .. code:: python
 
@@ -55,6 +66,8 @@ The ``.run(...)`` method takes in a compiled program. You are responsible for co
     ro = p.declare('ro', 'BIT', 1)
     p += X(0)
     p += MEASURE(0, ro[0])
+    p += MEASURE(1, ro[1])
+    p.wrap_in_numshots_loop(5)
     executable = qc.compile(p)
     results = qvm.run(executable)
     print(results)
@@ -63,25 +76,10 @@ The results returned are a *list of lists of integers*. In the above case, that'
 
 .. parsed-literal::
 
-    [[1]]
+    [[1, 0], [1, 0], [1, 0], [1, 0], [1, 0]]
 
-If we had changed the number of shots, like so:
-
-.. code:: python
-
-    # ...
-    p.wrap_in_numshots_loop(10)
-    executable = qc.compile(p)
-    # ...
-
-then in our results, we would see the following:
-
-.. parsed-literal::
-
-    [[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]
-
-Let's unpack this. The *outer* list is an
-enumeration over the trials; the argument given to ``wrap_in_numshots_loop`` will match the length of ``results``.
+Let's unpack this. The *outer* list is an enumeration over the trials; the argument given to
+``wrap_in_numshots_loop`` will match the length of ``results``.
 
 The *inner* list, on the other hand, is an enumeration over the results stored in the memory region named ``ro``, which
 we use as our readout register. We see that the result of this program is that the memory region ``ro[0]`` now stores


### PR DESCRIPTION
Still need to actually rewrite QVM page and improve, and later add QPU section, but at least the junk is cleared out.

Added references to man pages. @mpharrigan do we want those anywhere in the TOC?