### PR TITLE
Fix parsing DEFCIRCUIT without qubits

### DIFF
--- a/pyquil/_parser/PyQuilListener.py
+++ b/pyquil/_parser/PyQuilListener.py
@@ -128,11 +128,12 @@ class PyQuilListener(QuilListener):
         circuit_name = ctx.name().getText()
         variables = [variable.getText() for variable in ctx.variable()]
         qubitVariables = [qubitVariable.getText() for qubitVariable in ctx.qubitVariable()]
+        space = ' ' if qubitVariables else ''
 
         if variables:
-            raw_defcircuit = 'DEFCIRCUIT {}({}) {}:'.format(circuit_name, ', '.join(variables), ' '.join(qubitVariables))
+            raw_defcircuit = 'DEFCIRCUIT {}({}){}{}:'.format(circuit_name, ', '.join(variables), space, ' '.join(qubitVariables))
         else:
-            raw_defcircuit = 'DEFCIRCUIT {} {}:'.format(circuit_name, ' '.join(qubitVariables))
+            raw_defcircuit = 'DEFCIRCUIT {}{}{}:'.format(circuit_name, space, ' '.join(qubitVariables))
 
         raw_defcircuit += '\n    '.join([''] + [instr.out() for instr in self.result])
         self.previous_result.append(RawInstr(raw_defcircuit))

--- a/pyquil/tests/test_parser.py
+++ b/pyquil/tests/test_parser.py
@@ -213,7 +213,13 @@ DEFCIRCUIT bell a b:
     H a
     CNOT a b
 """.strip()
+    defcircuit_no_qubits = """
+DEFCIRCUIT bell:
+    H 0
+    CNOT 0 1
+""".strip()
     parse_equals(defcircuit, RawInstr(defcircuit))
+    parse_equals(defcircuit_no_qubits, RawInstr(defcircuit_no_qubits))
 
 
 def test_parse_reset_qubit():


### PR DESCRIPTION
Parsing a DEFCIRCUIT which has no qubit parameters outputs an
extraneous spacing before the colon:

```
>>> from pyquil.parser import parse
>>> from pyquil._parser.PyQuilListener import run_parser
>>> from pyquil.quilbase import RawInstr
>>> print(run_parser("DEFCIRCUIT TEST:\n    MEASURE 0 ro\n"))'

[<RawInstr DEFCIRCUIT TEST :
    MEASURE 0 ro[0]>]
```