### PR TITLE
Add reset method to QuantumComputer and QAM to return to initial state

### DIFF
--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -39,13 +39,7 @@ class QAM(ABC):
 
     @_record_call
     def __init__(self):
-        self._variables_shim = {}
-        self._n_shots = None
-        self._n_bits = None
-        self._executable = None
-        self._bitstrings = None
-
-        self.status = 'connected'
+        self.reset()
 
     @_record_call
     def load(self, executable):

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -138,3 +138,18 @@ class QAM(ABC):
             raise QAMError("Bitstrings have not yet been populated. Something has gone wrong.")
 
         return self._bitstrings
+
+    @_record_call
+    def reset(self):
+        """
+        Reset the Quantum Abstract Machine to its initial state, which is particularly useful
+        when it has gotten into an unwanted state. This can happen, for example, if the QAM
+        is interrupted in the middle of a run.
+        """
+        self._variables_shim = {}
+        self._n_shots = None
+        self._n_bits = None
+        self._executable = None
+        self._bitstrings = None
+
+        self.status = 'connected'

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -141,8 +141,6 @@ class QAM(ABC):
         is interrupted in the middle of a run.
         """
         self._variables_shim = {}
-        self._n_shots = None
-        self._n_bits = None
         self._executable = None
         self._bitstrings = None
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -269,6 +269,12 @@ class QuantumComputer:
         binary = self.compiler.native_quil_to_executable(nq_program)
         return binary
 
+    def reset(self):
+        """
+        Reset the QuantumComputer's QAM to its initial state.
+        """
+        self.qam.reset()
+
     def __str__(self) -> str:
         return self.name
 

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -12,7 +12,7 @@ from pyquil.device import NxDevice, gates_in_isa
 from pyquil.gates import *
 from pyquil.quilbase import Declare, MemoryReference
 from pyquil.noise import decoherence_noise_with_asymmetric_ro
-from rpcq.messages import PyQuilExecutableResponse
+from rpcq.messages import ParameterAref, PyQuilExecutableResponse
 
 
 class DummyCompiler(AbstractCompiler):
@@ -344,3 +344,37 @@ def test_run_with_parameters(forest):
 
     assert bitstrings.shape == (1000, 1)
     assert all([bit == 1 for bit in bitstrings])
+
+
+def test_reset(forest):
+    device = NxDevice(nx.complete_graph(3))
+    qc = QuantumComputer(
+        name='testy!',
+        qam=QVM(connection=forest),
+        device=device,
+        compiler=DummyCompiler()
+    )
+    p = Program(
+            Declare(name='theta', memory_type='REAL'),
+            Declare(name='ro', memory_type='BIT'),
+            RX(MemoryReference('theta'), 0),
+            MEASURE(0, MemoryReference('ro'))
+        ).wrap_in_numshots_loop(1000)
+    qc.run(
+        executable=p,
+        memory_map={'theta': [np.pi]}
+    )
+
+    aref = ParameterAref(name='theta', index=0)
+    assert qc.qam._variables_shim[aref] == np.pi
+    assert qc.qam._executable == p
+    assert qc.qam._bitstrings.shape == (1000, 1)
+    assert all([bit == 1 for bit in qc.qam._bitstrings])
+    assert qc.qam.status == 'done'
+
+    qc.reset()
+
+    assert qc.qam._variables_shim == {}
+    assert qc.qam._executable == None
+    assert qc.qam._bitstrings == None
+    assert qc.qam.status == 'connected'

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -355,11 +355,11 @@ def test_reset(forest):
         compiler=DummyCompiler()
     )
     p = Program(
-            Declare(name='theta', memory_type='REAL'),
-            Declare(name='ro', memory_type='BIT'),
-            RX(MemoryReference('theta'), 0),
-            MEASURE(0, MemoryReference('ro'))
-        ).wrap_in_numshots_loop(1000)
+        Declare(name='theta', memory_type='REAL'),
+        Declare(name='ro', memory_type='BIT'),
+        RX(MemoryReference('theta'), 0),
+        MEASURE(0, MemoryReference('ro'))
+    ).wrap_in_numshots_loop(1000)
     qc.run(
         executable=p,
         memory_map={'theta': [np.pi]}
@@ -375,6 +375,6 @@ def test_reset(forest):
     qc.reset()
 
     assert qc.qam._variables_shim == {}
-    assert qc.qam._executable == None
-    assert qc.qam._bitstrings == None
+    assert qc.qam._executable is None
+    assert qc.qam._bitstrings is None
     assert qc.qam.status == 'connected'


### PR DESCRIPTION
I was able to put a `QPU`-backed `QuantumComputer` object into a weird state by `C-c`'ing during a call to `QuantumComputer.run`, so this facility should help.

**Bonus**: Removed unused `_n_shots` and `_n_bits` attributes from the `QAM`