### PR TITLE
Removing redundant code used to calculate powers of PauliTerms

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -232,14 +232,12 @@ class PauliTerm(object):
         """
         if not isinstance(power, int) or power < 0:
             raise ValueError("The power must be a non-negative integer.")
-        result = ID()
 
-        identities = [PauliTerm('I', qubit) for qubit in self.get_qubits()]
-        if not identities:
+        if len(self.get_qubits()) == 0:
             # There weren't any nontrivial operators
             return term_with_coeff(self, 1)
-        for identity in identities:
-            result *= identity
+
+        result = ID()
         for _ in range(power):
             result *= self
         return result


### PR DESCRIPTION
Removing some redundant (and confusing) code used in calculating the result for a PauliTerm raised to some (integer) power. For one, the identity multiplied by several identities will always just yield an identity. Secondly, we can check for triviality by simply checking for the number of qubits being operated on[*], instead of more convolutedly checking whether the list of identities operating on the available qubits is an empty list or not.

[*] This itself seems like a dubious check, since presumably we are unable to ever create a `PauliTerm` with no qubits, even if we do something like `PauliTerm.from_list([])`. We can nevertheless check for this in a less confusing manner, as in the code change here.

UPDATE:
** (Correcting myself on point [*])
It is indeed possible to produce a `PauliTerm` with no qubits, though if we print out the `PauliTerm`, it would seem that it's applying an identity operation on some non-zero number of qubits:

```
>>> import pyquil.paulis as pl
>>> pt = pl.PauliTerm.from_list([])
>>> print (pt)
(1+0j)*I
>>> pt.get_qubits()
[]
>>> pt._ops
OrderedDict()
```