### PR TITLE
Small doc-string/code improvement for check_commutation

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -657,8 +657,9 @@ def simplify_pauli_sum(pauli_sum):
 def check_commutation(pauli_list, pauli_two):
     """
     Check if commuting a PauliTerm commutes with a list of other terms by natural calculation.
-    Derivation similar to arXiv:1405.5749v2 fo the check_commutation step in
-    the Raesi, Wiebe, Sanders algorithm (arXiv:1108.4318, 2011).
+    Uses the result in Section 3 of arXiv:1405.5749v2, modified slightly here to check for the
+    number of anti-coincidences (which must always be even for commuting PauliTerms)
+    instead of the no. of coincidences, as in the paper.
 
     :param list pauli_list: A list of PauliTerm objects
     :param PauliTerm pauli_two_term: A PauliTerm object
@@ -675,7 +676,7 @@ def check_commutation(pauli_list, pauli_two):
                 non_similar += 1
         return non_similar % 2 == 0
 
-    for i, term in enumerate(pauli_list):
+    for term in pauli_list:
         if not coincident_parity(term, pauli_two):
             return False
     return True


### PR DESCRIPTION
Minor doc-string improvement: The logic for check_commutation really only uses a result from `arXiv:1405.5749v2` (and not also `arXiv:1108.4318`, so this ref is removed). Furthermore, in that paper, the result says that two PauliTerms commute when the number of "coincidences" (i.e. same operator for same qubit) is even if the number of qubits is even, and is odd when the number of qubits is odd -- this is the same as checking that the number of non-coincidences is always even, and this is clarified in the doc-string.

Minor code improvement: We never use the index of the pauli_list, so we simply loop over the terms in this list, instead of its enumerated version.